### PR TITLE
Update decode-verify-jwt.py

### DIFF
--- a/Cognito/decode-verify-jwt/decode-verify-jwt.py
+++ b/Cognito/decode-verify-jwt/decode-verify-jwt.py
@@ -45,9 +45,9 @@ def lambda_handler(event, context):
     # message and signature (encoded in base64)
     message, encoded_signature = str(token).rsplit('.', 1)
     # decode the signature
-    decoded_signature = base64url_decode(encoded_signature)
+    decoded_signature = base64url_decode(encoded_signature.encode('utf-8'))
     # verify the signature
-    if not public_key.verify(message, decoded_signature):
+    if not public_key.verify(message.encode("utf8"), decoded_signature):
         print('Signature verification failed')
         return False
     print('Signature successfully verified')


### PR DESCRIPTION
Problem : TypeError: must be str, not bytes in Python 3.6.4