### PR TITLE
Modify return value of get_boot_time to time_t

### DIFF
--- a/OpsWorks/sample-cookbooks/cpulimit-ruby/files/default/cpulimit-master/src/process_iterator.h
+++ b/OpsWorks/sample-cookbooks/cpulimit-ruby/files/default/cpulimit-master/src/process_iterator.h
@@ -48,7 +48,7 @@ struct process {
 	//ppid of the process
 	pid_t ppid;
 	//start time (unix timestamp)
-	int starttime;
+	time_t starttime;
 	//cputime used by the process (in milliseconds)
 	int cputime;
 	//actual cpu usage estimation (value in range 0-1)
@@ -66,7 +66,7 @@ struct process_filter {
 struct process_iterator {
 #ifdef __linux__
 	DIR *dip;
-	int boot_time;
+	time_t boot_time;
 #elif defined __FreeBSD__
 	kvm_t *kd;
 	struct kinfo_proc *procs;

--- a/OpsWorks/sample-cookbooks/cpulimit-ruby/files/default/cpulimit-master/src/process_iterator_linux.c
+++ b/OpsWorks/sample-cookbooks/cpulimit-ruby/files/default/cpulimit-master/src/process_iterator_linux.c
@@ -13,7 +13,7 @@
 
 #include <sys/vfs.h>
 
-static int get_boot_time()
+static time_t get_boot_time()
 {
 	int uptime = 0;
 	FILE *fp = fopen ("/proc/uptime", "r");


### PR DESCRIPTION
Since time_t value returns a 64bit value(like long or longlong), get_boot_time() should return a 64 bit value instead of int. Other wise, get_boot_time() might not return a correct boot time.