### PR TITLE
Changed ThreadPoolExecutor to use a with statement as per python docs

### DIFF
--- a/SES/SESMailer/ses_mailer.py
+++ b/SES/SESMailer/ses_mailer.py
@@ -114,14 +114,13 @@ def lambda_handler(event, context):
             raise ValueError('Cannot continue without a text or html message file.')
 
         # Send in parallel using several threads
-        e = concurrent.futures.ThreadPoolExecutor(max_workers=max_threads)
-        for row in reader:
-            from_address = row['from_address'].strip()
-            to_address = row['to_address'].strip()
-            subject = row['subject'].strip()
-            message = mime_email(subject, from_address, to_address, mime_message_text, mime_message_html)
-            e.submit(send_mail, from_address, to_address, message)
-        e.shutdown()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_threads) as e:
+            for row in reader:
+                from_address = row['from_address'].strip()
+                to_address = row['to_address'].strip()
+                subject = row['subject'].strip()
+                message = mime_email(subject, from_address, to_address, mime_message_text, mime_message_html)
+                e.submit(send_mail, from_address, to_address, message)
     except Exception as e:
         print(e.message + ' Aborting...')
         raise e


### PR DESCRIPTION
I've been having issues with the SESMailer reaching a maximum amount of threads.  #68 

Despite using a `ThreadPoolExecutor`,  the Lambda was continuously creating new threads and never disposing of the old ones, eventually reaching it's maximum amount. The culprit in `ses_mailer.py` was that the `ThreadPoolExecutor` isn't being used correctly here and doesn't ensure proper thread disposal. It should instead be used with a `with` statement. As found in the [python docs for ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html).