### PR TITLE
Script to automate the configuration of IAM Authentication for Postgres

### DIFF
--- a/RDS/Postgres/README.md
+++ b/RDS/Postgres/README.md
@@ -5,8 +5,7 @@ AWS CLI must be installed and configured properly. User/profile configured with 
 
 ## Limitations:
 * EC2 Roles currently not supported.
-* Tested on version 10.6 only, should work with 9.6.11 or higher, and 9.5.15 or higher. [Documentation here.]
-(https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html#UsingWithRDS.IAMDBAuth.Availability)
+* Tested on version 10.6 only, should work with 9.6.11 or higher, and 9.5.15 or higher. [Documentation here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html#UsingWithRDS.IAMDBAuth.Availability)
 
 ## Usage:
 Step 1: Go to RDS Console, select the instance, click on "Modify", "Enable IAM Authentication", "Next", "Apply immediately".

--- a/RDS/Postgres/README.md
+++ b/RDS/Postgres/README.md
@@ -1,0 +1,35 @@
+# Setup IAM Authentication for RDS / Aurora Postgresql
+
+## Pre-requisites:
+AWS CLI must be installed and configured properly. User/profile configured with AWS CLI must be able to create IAM resources.
+
+## Limitations:
+* EC2 Roles currently not supported.
+* Tested on version 10.6 only, should work with 9.6.11 or higher, and 9.5.15 or higher. [Documentation here.]
+(https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html#UsingWithRDS.IAMDBAuth.Availability)
+
+## Usage:
+Step 1: Go to RDS Console, select the instance, click on "Modify", "Enable IAM Authentication", "Next", "Apply immediately".
+
+Step 2: Open up a terminal and run the command below and follow the instructions.
+```
+curl -L https://raw.githubusercontent.com/awslabs/aws-support-tools/master/RDS/Postgres/setupIAM-Postgres.sh > /tmp/setupIAM-Postgres.sh && \
+chmod +x /tmp/setupIAM-Postgres.sh && /tmp/setupIAM-Postgres.sh
+```
+Step 3: Connect to the database using your master user, create the database user and grant the rds_iam role:
+```
+iamdemo=> create user <USER> with login;
+CREATE ROLE
+iamdemo=> grant rds_iam to <USER>;
+GRANT ROLE
+iamdemo=> \q
+```
+Step 4: Use the script created under the home directory to generate the authentication token and connection string
+```
+$ . ~/.pg_<USER>
+```
+Example:
+```
+$ . ~/.pg_bruno 
+psql "host=postgres-13279.c3zv6fovsjeu.ap-southeast-2.rds.amazonaws.com dbname=IAMDB user=bruno sslrootcert=rds-combined-ca-bundle.pem sslmode=verify-full"
+```

--- a/RDS/Postgres/setupIAM-Postgres.sh
+++ b/RDS/Postgres/setupIAM-Postgres.sh
@@ -1,5 +1,29 @@
 #!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+# 
+#     http://aws.amazon.com/apache2.0/
+# 
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under the License.
+
 ## Functions ##
+securityDisclaimer(){
+    # This function just lets the user know what will be done so he can cancel before doing anything if he wants.
+    cat << EOF
+Info: Executing this script will:
+    1. Query your account ID from AWS CLI.
+    2. Create IAM Policy and Role.
+    3. Download SSL certificate to this machine.
+    4. Create parameter file on ${HOME}
+
+EOF
+    read -p "Do you wish to proceed Y/N? [N]: " DECISION; DECISION=${DECISION:-N}; echo $DECISION
+    if [[ ${DECISION} == y ]] || [[ ${DECISION} == Y ]]; then echo "Proceeding..."; else exit 1; fi
+}
 getAccountID(){
     # This requires AWS CLI to be properly configured!
     ACC_ID="$(aws sts get-caller-identity --query "[Account]" --output text)"
@@ -93,6 +117,7 @@ validateSettings(){
 }
 
 ## MAIN Workflow ##
+securityDisclaimer
 getAccountID
 loadVariables
 createJSONPolicy

--- a/RDS/Postgres/setupIAM-Postgres.sh
+++ b/RDS/Postgres/setupIAM-Postgres.sh
@@ -111,7 +111,13 @@ then
     echo ". ~/.pg_${IAM_USER}"
     exit 1
 else
-    echo "Environment configured successfully."
+    echo ''
+    echo "*** Environment configured successfully ***"
+    echo ''
+    echo "Please connect with the master user to your database and execute the following commands: "
+    echo "create user ${IAM_USER} with login;"
+    echo "grant rds_iam to ${IAM_USER};"
+    echo ''
     echo "You can connect to the database now with the following connection string: "
     echo "${CONN}"
     echo ''

--- a/RDS/Postgres/setupIAM-Postgres.sh
+++ b/RDS/Postgres/setupIAM-Postgres.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+## Functions ##
+getAccountID(){
+    # This requires AWS CLI to be properly configured!
+    ACC_ID="$(aws sts get-caller-identity --query "[Account]" --output text)"
+    echo "Account ID: ${ACC_ID}"
+    return 0
+}
+loadVariables() {
+    read -p "Role Name [IAMDBAuthPostgresRole]: " ROLE_NAME; ROLE_NAME=${ROLE_NAME:-IAMDBAuthPostgresRole}
+    read -p "Policy Name [IAMDBAuthPostgresPolicy]: " POLICY_NAME; POLICY_NAME=${POLICY_NAME:-IAMDBAuthPostgresPolicy}
+    read -p "Region [us-east-1]: " REGION; REGION=${REGION:-us-east-1}
+    read -p "DB Resource ID [*]: " DB_RES_ID; DB_RES_ID=${DB_RES_ID:-*}
+    read -p "IAM User: " IAM_USER
+    return 0
+}
+createJSONPolicy() {
+cat << EOF > rds-iam-policy.json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds-db:connect"
+            ],
+            "Resource": [
+                "arn:aws:rds:${REGION}:${ACC_ID}:dbuser:${DB_RES_ID}/${IAM_USER}"
+            ]
+        }
+    ]
+}
+EOF
+POLICY_ARN="arn:aws:iam::${ACC_ID}:policy/${POLICY_NAME}"
+return 0
+}
+createJSONRole() {
+cat << EOF > rds-iam-role.json
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": { "AWS": "arn:aws:iam::${ACC_ID}:root" },
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+ROLE_ARN="arn:aws:iam::${ACC_ID}:role/${POLICY_NAME}"
+return 0
+}
+createIAMPolicy() {
+    aws iam create-policy --policy-name ${POLICY_NAME} --policy-document file://rds-iam-policy.json
+    return 0
+}
+createIAMRole() {
+    aws iam create-role --role-name ${ROLE_NAME} --assume-role-policy-document file://rds-iam-role.json
+    return 0
+}
+attachIAMPolicyToRole(){
+    aws iam attach-role-policy --policy-arn ${POLICY_ARN} --role-name ${ROLE_NAME}
+    return 0
+}
+getSSLCertificate(){
+    if [[ -f rds-combined-ca-bundle.pem ]] 
+    then 
+        return 0
+    else 
+        wget https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /tmp/ssl.log
+        if [[ $? > 0 ]]; then echo "Failed to download SSL Certificate" && exit 1; else return 0; fi
+    fi
+}
+createParameterFile() {
+if [[ -f ~/.pg_${IAM_USER} ]]; then exit 0; fi
+    echo "Please provide database details to create the parameter file that will be used to generate the authentication token."
+    read -p "Database Endpoint: " RDSHOST
+    read -p "Database Port: [5432] " RDSPORT; RDSPORT=${RDSPORT:-5432}
+    read -p "Database Name: " RDSDB
+cat << EOF > ~/.pg_${IAM_USER} 
+export RDSHOST="${RDSHOST}"
+export RDSPORT="${RDSPORT}"
+export RDSDB="${RDSDB}"
+export REGION="${REGION}"
+export IAM_USER="${IAM_USER}"
+export CONN="psql \"host=$RDSHOST dbname=$RDSDB user=$IAM_USER sslrootcert=rds-combined-ca-bundle.pem sslmode=verify-full\""
+EOF
+echo "export PGPASSWORD=\"\$(aws rds generate-db-auth-token --hostname \$RDSHOST --port \$RDSPORT --region \$REGION --username \$IAM_USER)\"" >> ~/.pg_${IAM_USER}
+echo "echo \$CONN" >> ~/.pg_${IAM_USER} 
+return 0
+}
+validateSettings(){
+    if [[ -z $ACC_ID ]]; then echo "Failed to get Account ID, make sure your AWS CLI is properly configured." && exit 1; fi
+    if [[ -z $IAM_USER ]]; then echo "No IAM user was entered. Rerun the script and enter the IAM User." && exit 1; fi
+}
+
+## MAIN Workflow ##
+getAccountID
+loadVariables
+createJSONPolicy
+createJSONRole
+validateSettings
+createIAMPolicy
+createIAMRole
+attachIAMPolicyToRole
+createParameterFile
+getSSLCertificate
+. ~/.pg_${IAM_USER} > /dev/null
+if [[ -z $PGPASSWORD ]] 
+then 
+    echo "Environment configured, but token creation failed."
+    echo "Try again later by running the command below:"
+    echo ". ~/.pg_${IAM_USER}"
+    exit 1
+else
+    echo "Environment configured successfully."
+    echo "You can connect to the database now with the following connection string: "
+    echo "${CONN}"
+    echo ''
+    echo "You can generate tokens and get the connection string at any time by running: "
+    echo ". ~/.pg_${IAM_USER}"
+    exit 0
+fi


### PR DESCRIPTION
This script requires AWS CLI to be properly configured and requires privileges to create IAM Role and Policy, it will prompt for the values once executed and will create a script under the user home directory, which can be invoked to  generate new tokens and display the connection string.

Usage:
cd /path/to/file
./setupIAM-postgres.sh

Once the setup is complete, just execute the command below to get new token and connection string.
. ~/.pg_<IAM_User> (This is displayed at the end of execution of the script for convenience).