### PR TITLE
Scripts and cloud-init directives to automates the installation and configuration of Dnsmasq on Amazon Linux 1 & 2.

### DIFF
--- a/EC2/AutomateDnsmasq/AutomateDnsmasq.cloudinit
+++ b/EC2/AutomateDnsmasq/AutomateDnsmasq.cloudinit
@@ -1,0 +1,65 @@
+#cloud-config
+
+########################################################################
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under the License
+
+
+########################################################################
+
+# The aim of this cloud-init directive is to automate the installation and configuration of DNSMasq services on Amazon Linux 1 & 2
+# This should be injected as user-data on instance during the launch process
+
+# Install dnsmasq package
+packages: 
+  - dnsmasq
+
+# Create dnsmasq user
+users: 
+  - default
+  - name: dnsmasq
+    inactive: true
+    system: true
+
+# Run Shell commands to configure dnsmasq
+runcmd:
+ 
+  # Start dnsmask service and enable it to start at every reboot
+  - pidof systemd && systemctl restart dnsmasq.service || service dnsmasq restart
+  - pidof systemd && systemctl enable  dnsmasq.service || chkconfig dnsmasq on
+
+  # Configure /etc/dhcp/dhclient.conf and /etc/resolv.dnsmasqwith the right DNS IP Address
+  # Note that this DNS is set to 169.254.169.253 for VPC and to 172.16.0.23 for ec2-classic
+  - INTERFACE=$(curl --silent http://169.254.169.254/latest/meta-data/network/interfaces/macs/ | head -n1); 
+    IS_IT_CLASSIC=$(curl --write-out %{http_code} --silent --output /dev/null http://169.254.169.254/latest/meta-data/network/interfaces/macs/${INTERFACE}/vpc-id); 
+    if [[ $IS_IT_CLASSIC == '404' ]]; then bash -c "echo 'supersede domain-name-servers 127.0.0.1, 172.16.0.23;' >> /etc/dhcp/dhclient.conf && echo 'nameserver 172.16.0.23' > /etc/resolv.dnsmasq"; else  bash -c "echo 'supersede domain-name-servers 127.0.0.1, 169.254.169.253;' >> /etc/dhcp/dhclient.conf && echo 'nameserver 169.254.169.253' > /etc/resolv.dnsmasq"; fi
+
+  # Restart dhclient
+  - bash -c "dhclient"
+
+# Configure /etc/dnsmasq.conf accordingly
+write_files: 
+  - path: /etc/dnsmasq.conf
+    content: |
+        # Server Configuration
+        listen-address=127.0.0.1
+        port=53
+        bind-interfaces
+        user=dnsmasq
+        group=dnsmasq
+        pid-file=/var/run/dnsmasq.pid
+        # Name resolution options
+        resolv-file=/etc/resolv.dnsmasq
+        cache-size=500
+        neg-ttl=60
+        domain-needed
+        bogus-priv

--- a/EC2/AutomateDnsmasq/AutomateDnsmasq.sh
+++ b/EC2/AutomateDnsmasq/AutomateDnsmasq.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+########################################################################
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under the License
+
+
+########################################################################
+
+
+# The aim of this script is to automate the installation and configuration of DNSMasq services on Amazon Linux 1 & 2
+# The script needs no argument and could be use either stand-alone, injected as user-data or use with AWS Systems Manager Run Command AWS-RunShellScript
+
+# Check whether this is to run on VPC (default) or EC2 classic and set NAMESERVER accordingly
+INTERFACE=$(curl --silent http://169.254.169.254/latest/meta-data/network/interfaces/macs/ | head -n1)
+IS_IT_CLASSIC=$(curl --write-out %{http_code} --silent --output /dev/null http://169.254.169.254/latest/meta-data/network/interfaces/macs/${INTERFACE}/vpc-id)
+
+if [[ $IS_IT_CLASSIC == '404' ]]
+then
+  NAMESERVER="172.16.0.23"
+else
+  NAMESERVER="169.254.169.253"
+fi
+
+# Install dnsmasq package
+yum install -y dnsmasq
+
+# Create the required User and Group
+groupadd -r dnsmasq
+useradd -r -g dnsmasq dnsmasq
+
+# Set dnsmasq.conf configuration
+cat << EOF > /etc/dnsmasq.conf
+# Server Configuration
+listen-address=127.0.0.1
+port=53
+bind-interfaces
+user=dnsmasq
+group=dnsmasq
+pid-file=/var/run/dnsmasq.pid
+# Name resolution options
+resolv-file=/etc/resolv.dnsmasq
+cache-size=500
+neg-ttl=60
+domain-needed
+bogus-priv
+EOF
+
+# Populate /etc/resolv.dnsmasq
+echo "nameserver ${NAMESERVER}" > /etc/resolv.dnsmasq
+
+# Enable and Start dnsmasq service
+pidof systemd && systemctl restart dnsmasq.service || service dnsmasq restart
+pidof systemd && systemctl enable  dnsmasq.service || chkconfig dnsmasq on
+
+# Test the service and configure dhclient accordingly
+dig aws.amazon.com @127.0.0.1 && echo "supersede domain-name-servers 127.0.0.1, ${NAMESERVER};" >> /etc/dhcp/dhclient.conf && dhclient

--- a/EC2/AutomateDnsmasq/README.md
+++ b/EC2/AutomateDnsmasq/README.md
@@ -1,0 +1,7 @@
+Bash Script AutomateDnsmasq.sh	
+=================================================
+The Bash script AutomateDnsmasq.sh automates the installation and configuration of Dnsmasq on Amazon Linux 1 & 2. It could be used as a standalone script, injected as User data during the Launch of an AWS EC2 instance, or used with AWS Systems Manager Run Command to perform the actions on existing instances with SSM Agent configured.
+
+Cloud-init Directives AutomateDnsmasq.cloudinit		
+===============================================
+The Cloud-init Directives AutomateDnsmasq.cloudinit	automates the installation and configuration of Dnsmasq on Amazon Linux 1 & 2 and should be injected as user-data during the instance launch.

--- a/EC2/AutomateDnsmasq/README.md
+++ b/EC2/AutomateDnsmasq/README.md
@@ -5,3 +5,17 @@ The Bash script AutomateDnsmasq.sh automates the installation and configuration 
 Cloud-init Directives AutomateDnsmasq.cloudinit		
 ===============================================
 The Cloud-init Directives AutomateDnsmasq.cloudinit	automates the installation and configuration of Dnsmasq on Amazon Linux 1 & 2 and should be injected as user-data during the instance launch.
+
+Details of steps performed on both the Bash script and the Cloud-init Directives
+=================================================================================
+The following step will be automatically performed by the Bash script and the Cloud-init directives:
+
+  - Install dnsmasq package (if not already installed)
+
+  - Create the appropriate dnsmasq user and group
+  
+  - Set /etc/dnsmasq.conf configuration and start the dnsmasq service
+  
+  - Configure /etc/dhcp/dhclient.conf and /etc/resolv.dnsmasq with the right DNS IP Address ( Note that this DNS is set to 169.254.169.253 for VPC and to 172.16.0.23 for ec2-classic)
+  
+  - Configure /etc/dhcp/dhclient.conf and trigger dhclient


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding Bash Scripts and cloud-init directives that automates the installation and configuration of Dnsmasq on Amazon Linux 1 & 2.  These will be referenced on 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
