### PR TITLE
Glue ETL script - Access a cross-region DynamoDB table in a Glue Job

### DIFF
--- a/Glue/ETL_Job_DynamoDB_Cross_Region/README.md
+++ b/Glue/ETL_Job_DynamoDB_Cross_Region/README.md
@@ -1,12 +1,12 @@
 # Access a cross-region DynamoDB table in a Glue Job? #
 
-##Problem
+## Problem
 
 When using the Glue ETL API, we cannot currently (2019.Q2) create DynamicFrames from DynamoDB tables in a different region using Glue Connections or Glue Data Catalog. The Glue Data Catalog can only add metadata tables for DynamoDB tables using a crawler (manual tables can only be added for S3 data stores), and these Crawlers can only crawl DynamoDB tables in the same region as the Glue job. Creating DynamicFrames from Glue connections can also only be done from DynamoDB tables in the same region.
 
 
 
-##Solution
+## Solution
 
 Since the environment in which our driver program is running has the AWS SDK installed, we can import it into our program and use it to pull data from the DynamoDB table in another region.  Once we have this data in a collection, we can create an RDD from it.
 

--- a/Glue/ETL_Job_DynamoDB_Cross_Region/README.md
+++ b/Glue/ETL_Job_DynamoDB_Cross_Region/README.md
@@ -1,11 +1,13 @@
 # Access a cross-region DynamoDB table in a Glue Job? #
 
-Problem
+##Problem
+
 When using the Glue ETL API, we cannot currently (2019.Q2) create DynamicFrames from DynamoDB tables in a different region using Glue Connections or Glue Data Catalog. The Glue Data Catalog can only add metadata tables for DynamoDB tables using a crawler (manual tables can only be added for S3 data stores), and these Crawlers can only crawl DynamoDB tables in the same region as the Glue job. Creating DynamicFrames from Glue connections can also only be done from DynamoDB tables in the same region.
 
 
 
-Solution
+##Solution
+
 Since the environment in which our driver program is running has the AWS SDK installed, we can import it into our program and use it to pull data from the DynamoDB table in another region.  Once we have this data in a collection, we can create an RDD from it.
 
 Spark's RDDs are the core data structures used to store data so that we can operate on them in parallel. Spark DataFrames and Glue DynamicFrames can be created from RDDs. So if we can get the DynamoDB table data from another region into an RDD, we can create a DataFrame or DynamicFrame from it and and transform the data using these familiar structured APIs.

--- a/Glue/ETL_Job_DynamoDB_Cross_Region/README.md
+++ b/Glue/ETL_Job_DynamoDB_Cross_Region/README.md
@@ -1,0 +1,32 @@
+# Access a cross-region DynamoDB table in a Glue Job? #
+
+Problem
+When using the Glue ETL API, we cannot currently (2019.Q2) create DynamicFrames from DynamoDB tables in a different region using Glue Connections or Glue Data Catalog. The Glue Data Catalog can only add metadata tables for DynamoDB tables using a crawler (manual tables can only be added for S3 data stores), and these Crawlers can only crawl DynamoDB tables in the same region as the Glue job. Creating DynamicFrames from Glue connections can also only be done from DynamoDB tables in the same region.
+
+
+
+Solution
+Since the environment in which our driver program is running has the AWS SDK installed, we can import it into our program and use it to pull data from the DynamoDB table in another region.  Once we have this data in a collection, we can create an RDD from it.
+
+Spark's RDDs are the core data structures used to store data so that we can operate on them in parallel. Spark DataFrames and Glue DynamicFrames can be created from RDDs. So if we can get the DynamoDB table data from another region into an RDD, we can create a DataFrame or DynamicFrame from it and and transform the data using these familiar structured APIs.
+
+There are two ways to create RDDs:
+
+Parallelizing existing collections
+Referencing a dataset in an external storage system.
+Since DynamoDB is not a Hadoop supported storage system, we will have to use the parallelizing approach.
+
+If we have a collection in our driver program, we can parallelize it into an RDD by using SparkContext's parallelize method. 
+
+Once we have the RDD, we can use the GlueContext's create_dynamic_frame_from_rdd method to create a DynamicFrame from an RDD.
+
+(Internally, GlueContext first calls it's parent class' (SQLContext) createDataFrame method to convert the RDD to a DataFrame, then creates a DynamicFrame from the DataFrame using DynamicFrame's fromDF method. See related items)
+
+We now have a DynamicFrame that we can transform and write out using the familiar Glue ETL API.
+
+What does this script do:
+
+- Uses boto3 to scan a DynamoDB table and puts the items returned into a list
+- Creates an RDD by parallelizing the list of items
+- Creates a DynamicFrame from the RDD
+- Writes the DynamicFrame to S3

--- a/Glue/ETL_Job_DynamoDB_Cross_Region/etl_dynamodb_cross_region.py
+++ b/Glue/ETL_Job_DynamoDB_Cross_Region/etl_dynamodb_cross_region.py
@@ -1,0 +1,45 @@
+#Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file 
+#except in compliance with the License. A copy of the License is located at
+#
+#    http://aws.amazon.com/apache2.0/
+#
+#or in the "license" file accompanying this file. This file is distributed on an "AS IS" 
+#BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+#License for the specific language governing permissions and limitations under the License.
+
+import sys
+import boto3
+from awsglue.transforms import *
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.dynamicframe import DynamicFrame
+from awsglue.job import Job
+
+sc = SparkContext.getOrCreate()
+gc = GlueContext(sc)
+job = Job(gc)
+
+#create dynamodb resource client to omit data type descriptors from returned collections when using low-level client
+ddb = boto3.resource('dynamodb', region_name='eu-west-1')
+
+#get table resource in another AWS region
+test_table = ddb.Table('test-table')
+
+# get table items from scan, pull items list from dictionary
+table_items = test_table.scan()['Items']
+
+# convert to RDD so we can use it in spark
+ddbRDD =  sc.parallelize(table_items)
+
+# if you only want a DataFrame, create DataFrame from RDD using SQLContext (GlueContext can only create DynamicFrames from RDDs, not DataFrames)
+#ddbDataFrame = gc.createDataFrame(ddbRDD)
+
+#create DynamicFrame from RDD using GlueContext
+ddbDynamicFrame = gc.create_dynamic_frame_from_rdd(ddbRDD, "ddbDFrame")
+
+#write to S3
+datasink = gc.write_dynamic_frame.from_options(frame = ddbDynamicFrame, connection_type = "s3",connection_options = { "path":  "s3://your-glue-target-bucket"}, format="json")
+
+job.commit()  

--- a/Glue/README.md
+++ b/Glue/README.md
@@ -1,0 +1,1 @@
+# Glue Support Tools


### PR DESCRIPTION
*Description of changes:*
Added Glue ETL scripts on how to access DynamoDB tables in an ETL job across AWS regions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
