### PR TITLE
Make the script detect static linked NVMe driver #86

### DIFF
--- a/EC2/C5M5InstanceChecks/c5_m5_checks_script.sh
+++ b/EC2/C5M5InstanceChecks/c5_m5_checks_script.sh
@@ -126,7 +126,7 @@ if [ `id -u` -ne 0 ]; then                                              # Checks
         exit 1
 fi
 
-modinfo nvme > /dev/null 2>&1
+(modinfo nvme || grep 'nvme_open' /boot/System.map-$(uname -r)) > /dev/null 2>&1
 if [ $? -ne 0 ]
     then
     # NVMe Module is not installed. 


### PR DESCRIPTION
*Issue #, if available:*
#86

*Description of changes:*
Recent kernel bundled in Ubuntu 18.04 AMI at AWS has NVMe driver as a static linked
driver. So `modinfo nvme` won't work on it.
This change tries to find static linked NVMe driver as well as
loadable module if `modinfo nvme` fails.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
