### PR TITLE
fix: add required dependencies for script 

### DIFF
--- a/EC2/AutomateDnsmasq/AutomateDnsmasq.cloudinit
+++ b/EC2/AutomateDnsmasq/AutomateDnsmasq.cloudinit
@@ -22,6 +22,7 @@
 # Install dnsmasq package
 packages: 
   - dnsmasq
+  - bind-utils
 
 # Create dnsmasq user
 users: 

--- a/EC2/AutomateDnsmasq/AutomateDnsmasq.sh
+++ b/EC2/AutomateDnsmasq/AutomateDnsmasq.sh
@@ -32,7 +32,7 @@ else
 fi
 
 # Install dnsmasq package
-yum install -y dnsmasq
+yum install -y dnsmasq bind-utils
 
 # Create the required User and Group
 groupadd -r dnsmasq


### PR DESCRIPTION
*Description of changes:*
Script to setup dnsmasq assumes that `dig` is available. Ensure that `bind-utils` is installed since this provides `dig`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
