### PR TITLE
Build Lambda Layers Bash Scripts

### DIFF
--- a/Lambda/BuildLambdaLayers/LICENSE.txt
+++ b/Lambda/BuildLambdaLayers/LICENSE.txt
@@ -1,0 +1,11 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/Lambda/BuildLambdaLayers/NOTICE
+++ b/Lambda/BuildLambdaLayers/NOTICE
@@ -1,0 +1,2 @@
+BuildLambdaLayers
+Copyright [2019]-[2019] Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/Lambda/BuildLambdaLayers/README.md
+++ b/Lambda/BuildLambdaLayers/README.md
@@ -1,0 +1,34 @@
+# Lambda - Build Layers Shell Script
+
+Lambda Layers allow for updating of libraries/mobdules for Lambda quickly, without the efforts of creating a custom Lambda runtime.  These bash scripts help automate the download of libraries/modules and optionally, upload the layer and associate with a Lambda function.
+
+This is particularily helpful when adding [AWS X-Ray SDK](https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html), latest versions of the AWS SDK or older/newer versions of other libraries/modules needed when troubleshooting or deploying functions for A/B type testing.
+
+For more information on managing [Lambda layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
+
+## Requirements
+If you wish the script to upload the Lambda layer and deploy the layer to a Lambda function you will need [jq](https://stedolan.github.io/jq/) and zip.
+
+[AWSCLI](https://docs.aws.amazon.com/cli/latest/userguide/install-macos.html) will need to be installed and configured if you wish to upload layers and/or associate layers with Lambda functions.
+
+Each runtime will need to have the relevant package manager installed.  Details are in the relevant README.md of each runtime.
+
+## Permissions
+
+The following User/Role IAM permissions are required in your AWS Account to upload the layer and associate the layer with a Lambda function:
+ * Layer Development and Use [https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html#permissions-user-layer]
+ * This script does NOT assign resource policy's to the Lambda, you may need to consider adding permissions in certain scenarios. [https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-permissions]
+
+## Usage
+
+Each runtime has variences in how it is used - please check the README:
+ [python/README.md]()
+ [nodejs/README.md]()
+
+This script will use the credentials and region configured with the AWS CLI if available.  If not, AWSCLI it will ask for an AWS access key and secret key.
+
+### NOTE: Please test these sample scripts thoroughly to see if they suit your use case.
+
+
+
+Work Hard, Have Fun, Make History

--- a/Lambda/BuildLambdaLayers/nodejs/LICENSE.txt
+++ b/Lambda/BuildLambdaLayers/nodejs/LICENSE.txt
@@ -1,0 +1,11 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/Lambda/BuildLambdaLayers/nodejs/README.md
+++ b/Lambda/BuildLambdaLayers/nodejs/README.md
@@ -1,0 +1,36 @@
+# Lambda - Build Layers Shell Script - NodeJS
+
+This bash script will help with downloading modules and libraries to a local folder, zip and optionally upload the layer as a new version and associate with a Lambda Function if desired.
+
+## Usage
+
+'''bash
+./buildlayer.sh requirements.txt nodejs-version [lambda-version-name] [function-name]
+'''
+
+- requirements.txt is the list of python packages you wish to add to the layer.
+- node-version is the version of runtime the modules are downloaded for, eg 10.16.3
+  * https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html for the runtime currently supported.  
+- lambda-version-name (optional) if you want to upload the zip as a new version of an existing layer or as a new layer if no layer yet exists.
+- function-name (optional) if you want to add the layer to the $lastest of a lambda function.  This updates the Lambda immediately!
+
+This script will use the credentials and region configured with the AWS CLI if available.  If not, AWSCLI it will ask for an AWS access key and secret key.  
+
+## Requirements
+* If you wish the script to upload the Lambda layer and deploy the layer to a Lambda function you will need [jq](https://stedolan.github.io/jq/) and zip.
+* [virtualenv](https://pip.pypa.io/en/stable/installing/)
+* [pip](https://virtualenv.pypa.io/en/latest/)
+* [npm](https://www.npmjs.com/get-npm)
+* [nodeenv](https://github.com/ekalinin/nodeenv#install)
+* [AWSCLI](https://docs.aws.amazon.com/cli/latest/userguide/install-macos.html) will need to be installed and configured if you wish to upload layers and/or associate layers with Lambda functions.
+
+## Permissions
+The following User/Role IAM permissions are required in your AWS Account to upload the layer and associate the layer with a Lambda function:
+* Layer Development and Use [https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html#permissions-user-layer]
+* This script does NOT assign resource policy's to the Lambda layer, you may need to consider adding permissions in certain scenarios. [https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-permissions]
+
+### NOTE: Please test these sample scripts thoroughly to see if they suit your use case.
+
+
+
+Work Hard, Have Fun, Make History

--- a/Lambda/BuildLambdaLayers/nodejs/buildlayer.sh
+++ b/Lambda/BuildLambdaLayers/nodejs/buildlayer.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -o pipefail
+# Copyright [2019]-[2019] Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+# 
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under the License.
+#
+# --------------------
+# Purpose: Build layers to allow for module testing the latest libraries rapidly or for diagnostics such as
+#          X-Ray.  Please test thoroughly if this suits your use-case, and if you have any issues report via git issues
+# 
+# Note: This script can be used for any NodeJS version you choose to by specifying the version in the 
+#       bash script agrguments
+#
+# Example requirements.txt file:
+# 
+# aws-sdk
+# aws-xray-sdk
+#
+# Example of requirements file specifying versions:
+#
+# aws-xray-sdk@2.4.2
+# aws-sdk@1.9.243
+# 
+# Requirements to allow this script to upload layer and/or update lambda are AWSCLI & jq.
+# --------------------
+
+# Check if required args are passed on cmd line
+if ([ -f "$1" ] && [ "$2" != "" ]); then
+    echo "Starting to build package:"
+else
+    echo "ERR: Please provide the requirements file as a minimum."
+    echo ""
+    echo "Usage: buildlayer.sh requirements.txt node-version [lambda-version-name] [function-name]"
+    echo ""
+    echo " - requirements.txt is the list of python packages you wish to add to the layer. "
+    echo " - node-version is the version of runtime the modules are downloaded for, eg 10.16.3 "
+    echo "   * https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html for the runtime currently supported."    
+    echo " - lambda-version-name (optional) if you want to upload the zip as a new version of an existing layer or as a new layer if no layer yet exists."
+    echo " - function-name (optional) if you want to add the layer to the \$latest of a lambda function."
+    echo ""
+    echo "Example: buildlayer.sh requirements.txt 10.16.3 mylambda-version-name some-function-name"
+    echo ""
+    echo "Exiting."
+    exit 1
+fi
+
+# Clean out virt env 
+if [ -d "nodejs" ]; then
+  echo "Removing old nodejs folder."
+  rm -r nodejs
+fi
+if [ -d "v-env" ]; then
+  echo "Removing old v-env folder."
+  rm -r v-env
+fi
+
+dateofbackup=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# Backup previous layer built
+if [ -f layer.zip ]; then
+    echo "Copy layer.zip to layer-"$dateofbackup".zip"
+    cp layer.zip layer-backup-$dateofbackup.zip
+    rm layer.zip
+else 
+    echo "No previous layer file, no local backup occurred."
+fi
+
+echo "NodeJS virtual environment start:"
+# Build for a particular version
+# Check versions in our documentation: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
+# and node's past versions: https://nodejs.org/en/download/releases/
+nodeenv v-env --node="$2" --requirements="$1"
+
+# Activate virtual environment
+echo "Activate virtual environment:"
+. v-env/bin/activate
+
+# Start check Node version
+echo "Node Version:"
+node --version
+
+# Install modules per the provided requirements file and create folder structure needed for layer
+mkdir -p nodejs/node_modules
+cp -R v-env/lib/node_modules/ nodejs/node_modules/
+
+echo "Deactivate virtual enviroment:"
+deactivate_node
+
+echo "Zip packages to layer.zip:"
+zip -r9qdgds256k layer.zip nodejs/
+ls -l layer.zip
+
+# Publish layer if asked to
+if  [ "$3" != "" ]; then
+	echo "Adding new layer/version:" $3
+	arn=$(aws lambda publish-layer-version --layer-name $3 --zip-file fileb://layer.zip | jq '.LayerVersionArn' -r)
+	echo "Layer pubished: " $arn
+	# Update function if asked to
+	if [ "$3" != "" ]; then
+		echo "Updating Lambda function:" $4
+		aws lambda update-function-configuration --function-name $4 --layers $arn | jq
+	else
+		exit 0
+	fi
+else
+	exit 0
+fi

--- a/Lambda/BuildLambdaLayers/nodejs/requirements.txt
+++ b/Lambda/BuildLambdaLayers/nodejs/requirements.txt
@@ -1,0 +1,2 @@
+aws-sdk
+aws-xray-sdk

--- a/Lambda/BuildLambdaLayers/python/LICENSE.txt
+++ b/Lambda/BuildLambdaLayers/python/LICENSE.txt
@@ -1,0 +1,11 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# This file is licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/Lambda/BuildLambdaLayers/python/README.md
+++ b/Lambda/BuildLambdaLayers/python/README.md
@@ -1,0 +1,33 @@
+# Lambda - Build Layers Shell Script - Python
+
+This bash script will help with downloading modules and libraries using a python virtual environment, zip and optionally upload the layer as a new version and associate with a Lambda Function if desired.
+
+## Usage
+
+'''bash
+./buildlayer.sh requirements.txt [lambda-version-name] [function-name]
+'''
+
+- requirements.txt is the list of python packages you wish to add to the layer.
+- lambda-version-name (optional) if you want to upload the zip as a new version of an existing layer or as a new layer if no layer yet exists.
+- function-name (optional) if you want to add the layer to the $lastest of a lambda function. This updates the Lambda immediately!
+
+This script will use the credentials and region configured with the AWS CLI if available.  If not, AWSCLI it will ask for an AWS access key and secret key.
+
+## Requirements
+* If you wish the script to upload the Lambda layer and deploy the layer to a Lambda function you will need [jq](https://stedolan.github.io/jq/) and zip.
+* python 2.7 will need [virtualenv](https://pip.pypa.io/en/stable/installing/)
+* python 3.x will need [venv](https://docs.python.org/3/library/venv.html) 
+* [pip](https://virtualenv.pypa.io/en/latest/)
+* [AWSCLI](https://docs.aws.amazon.com/cli/latest/userguide/install-macos.html) will need to be installed and configured if you wish to upload layers and/or associate layers with Lambda functions.
+
+## Permissions
+The following User/Role IAM permissions are required in your AWS Account to upload the layer and associate the layer with a Lambda function:
+* Layer Development and Use [https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html#permissions-user-layer]
+* This script does NOT assign resource policy's to the Lambda layer, you may need to consider adding permissions in certain scenarios. [https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-permissions]
+
+### NOTE: Please test these sample scripts thoroughly to see if they suit your use case.
+
+
+
+Work Hard, Have Fun, Make History

--- a/Lambda/BuildLambdaLayers/python/buildlayer.sh
+++ b/Lambda/BuildLambdaLayers/python/buildlayer.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -euo pipefail
+# Copyright [2019]-[2019] Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+# 
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under the License.
+#
+# --------------------
+# Purpose: Build layers to allow for module testing the latest libraries rapidly or for diagnostics such as
+#          X-Ray.  Please test thoroughly if this suits your use-case, and if you have any issues report via git issues
+# 
+# Note: This script can be used for boto and boto3 / py2/3 as needed by changing #'s out as needed below.
+#
+# Example requirements.txt file:
+# 
+# boto3
+# aws-xray-sdk
+#
+# Example of requirements file specifying versions:
+#
+# aws-xray-sdk==2.4.2
+# boto3==1.9.243
+# 
+# Requirements to allow this script to upload layer and/or update lambda are AWSCLI & jq.
+# --------------------
+
+# Check if arg passed on cmd line
+if [ -f "$1" ]; then
+    echo "Starting to build package:"
+else
+    echo "ERR: Please provide the requirements file as a minimum."
+    echo ""
+    echo "Usage: buildlayer.sh requirements.txt [lambda-version-name] [function-name]"
+    echo ""
+    echo " - requirements.txt is the list of python packages you wish to add to the layer. "
+    echo " - lambda-version-name (optional) if you want to upload the zip as a new version of an existing layer or as a new layer if no layer yet exists."
+    echo " - function-name (optional) if you want to add the layer to the \$latest of a lambda function."
+    echo ""
+    exit 1
+fi
+
+# Clean out virt env 
+echo "Removing old virtual env/python folder"
+if [ -d "python" ]; then
+  rm -r python
+fi
+if [ -d "v-env" ]; then
+  rm -r v-env
+fi
+
+dateofbackup=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# Backup previous layer built
+if [ -f layer.zip ]; then
+    echo "Copy layer.zip to layer-"$dateofbackup".zip"
+    cp layer.zip layer-backup-$dateofbackup.zip
+    rm layer.zip
+else 
+    echo "No previous layer file, no local backup occurred."
+fi
+
+echo "Python virtual environment start:"
+# Python3.x
+# Alternative is to use virtualenv -p /usr/bin/python3 v-env
+python3 -m venv v-env
+# Can comment out the line above and remove the # below to allow Python2.7 virtual environments if you have python 2.7 installed
+#python2 -m virtualenv v-env
+
+# Activate virtual environment
+source v-env/bin/activate
+
+# Install modules per the provided requirements file
+echo "Download Python Packages..."
+pip install -q --no-cache-dir -r $1 -t python/
+
+echo "End virtual env..."
+# Deactive virtual environment
+deactivate
+
+echo "Zip packages..."
+# Zip the packages up
+zip -r9qdgds256k layer.zip python/
+ls -l layer.zip
+
+# Publish layer if asked to
+if  [ "$2" != "" ]; then
+	echo "Adding new layer or new layer version: "$2
+	arn=$(aws lambda publish-layer-version --layer-name $2 --zip-file fileb://layer.zip | jq '.LayerVersionArn' -r)
+	echo "Layer pubished: "$arn
+	# Update function if asked to
+	if [ "$3" != "" ]; then
+		echo "Updating Lambda function: "$3
+		aws lambda update-function-configuration --function-name $3 --layers $arn | jq
+	else
+		exit 0
+	fi
+else
+	exit 0
+fi

--- a/Lambda/BuildLambdaLayers/python/requirements.txt
+++ b/Lambda/BuildLambdaLayers/python/requirements.txt
@@ -1,0 +1,2 @@
+aws-xray-sdk
+boto3


### PR DESCRIPTION
Adding example scripts to build layers for Python and NodeJS Lambda functions.

*Issue #, if available:*

*Description of changes:*

Bash scripts to build python and nodejs layer zip files using virtual environments and then optionally upload a new Lambda version and update a Lambda function with said layer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
