### PR TITLE
update client_id claims key

### DIFF
--- a/Cognito/decode-verify-jwt/decode-verify-jwt.py
+++ b/Cognito/decode-verify-jwt/decode-verify-jwt.py
@@ -60,7 +60,7 @@ def lambda_handler(event, context):
         print('Token is expired')
         return False
     # and the Audience  (use claims['client_id'] if verifying an access token)
-    if claims['aud'] != app_client_id:
+    if claims['client_id'] != app_client_id:
         print('Token was not issued for this audience')
         return False
     # now we can use the claims


### PR DESCRIPTION
Decoded jwt payload contains no `aud` key. It has `client_id` key for audience client_id retrieval

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
