### PR TITLE
verify_env update

### DIFF
--- a/MWAA/readme.md
+++ b/MWAA/readme.md
@@ -17,6 +17,21 @@ This script may identify why.
 - Python3 is required to run this script
 - boto3 1.16.25 or newer
 
+### How to install and run
+```
+pip3 install boto3 --upgrade --user
+git clone https://github.com/awslabs/aws-support-tools.git
+python3 aws-support-tools/MWAA/verify_env/verify_env.py --envname YOUR_ENV_NAME_HERE
+```
+
+#### How can I send the output to a file automatically?
+
+##### Use a redirection operator
+python3 aws-support-tools/MWAA/verify_env/verify_env.py --envname YOUR_ENV_NAME_HERE > output.log
+
+##### Use vscode or codium
+python3 aws-support-tools/MWAA/verify_env/verify_env.py --envname YOUR_ENV_NAME_HERE | code -
+
 ### Logic and api calls
 The following actions will be performed in this order:
 

--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -615,6 +615,15 @@ def check_nacl(input_subnets, input_subnet_ids, ec2_client):
     print("")
 
 
+def check_vpc_endpoint_private_dns_enabled(vpc_endpnts):
+    '''short method to check if the interface's private dns option is set to true'''
+    for vpc_endpnt in vpc_endpnts:
+        if not vpc_endpnt['PrivateDnsEnabled'] and vpc_endpnt['VpcEndpointType'] == 'Interface':
+            print('VPC endpoint:', vpc_endpnt['VpcEndpointId'], "does not have private dns enabled")
+            print('this means that the public dns name for the service will resolve to its public IP and not')
+            print('the vpc endpoint private ip. You should enabled this for use with MWAA')
+
+
 def check_service_vpc_endpoints(ec2_client, subnets):
     '''
     should be used if the environment does not have internet access through NAT Gateway
@@ -660,6 +669,7 @@ def check_service_vpc_endpoints(ec2_client, subnets):
         for i, service_endpoint in enumerate(service_endpoints):
             if service_endpoint not in vpc_service_endpoints:
                 print(service_endpoint)
+        check_vpc_endpoint_private_dns_enabled(vpc_endpoints)
     else:
         print("The route for the subnets do not have a NAT Gateway. However, there are sufficient VPC endpoints")
 

--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -157,7 +157,7 @@ def check_iam_permissions(input_env, iam_client):
     for policy in policies:
         policy_arn = policy['PolicyArn']
         policy_version = iam_client.get_policy(PolicyArn=policy_arn)['Policy']['DefaultVersionId']
-        policy_doc = iam_client.get_policy_version(PolicyArn=policy_arn, 
+        policy_doc = iam_client.get_policy_version(PolicyArn=policy_arn,
                                                    VersionId=policy_version)['PolicyVersion']['Document']
         policy_list.append(json.dumps(policy_doc))
     eval_results = []
@@ -836,23 +836,21 @@ def check_connectivity_to_dep_services(input_env, input_subnets, ec2_client, ssm
 
 
 def check_for_failing_logs(loggroups, logs_client):
-    '''look for any failing logs from CloudWatch in the past day'''
-    print("### Checking CloudWatch logs for any errors less than 1 day old")
+    '''look for any failing logs from CloudWatch in the past hour'''
+    print("### Checking CloudWatch logs for any errors less than 1 hour old")
     now = int(time.time() * 1000)
-    past_day = now - 86400000
-    log_events = []
+    past_day = now - 3600000
+    print('Found the following failing logs in cloudwatch: ')
     for log in loggroups:
         events = logs_client.filter_log_events(
             logGroupName=log['logGroupName'],
-            startTime=now,
-            endTime=past_day,
+            startTime=past_day,
+            endTime=now,
             filterPattern='?ERROR ?Error ?error ?traceback ?Traceback ?exception ?Exception ?fail ?Fail'
         )['events']
         events = sorted(events, key=lambda i: i['timestamp'])
         for event in events:
-            log_events.append(event['timestamp'] + " " + event['message'])
-    print('Found the following failing logs in cloudwatch: ')
-    print(*log_events, sep="\n")
+            print(str(event['timestamp']) + " " + event['message'], end='')
 
 
 def print_err_msg(c_err):

--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -911,7 +911,7 @@ if __name__ == '__main__':
     parser.add_argument('--region', type=validation_region, default=boto3.session.Session().region_name,
                         required=False, help="region, Ex: us-east-1")
     parser.add_argument('--profile', type=validation_profile, default='default',
-                        required=False, help="profile, Ex: dev")
+                        required=False, help="AWS CLI profile, Ex: dev")
     args, _ = parser.parse_known_args()
     ENV_NAME = args.envname
     REGION = args.region


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- fixed issue with args to filter-log-events being reversed
- included more endpoints to test connectivity to. 
- changed logic when connectivity is tested. Now will do it when there is not a route to a NAT Gateway since that would suggest no internet access
- I'm then also checking if private dns is enabled on those endpoints

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
