### PR TITLE
Add logic to include inline policies on MWAA role

### DIFF
--- a/MWAA/readme.md
+++ b/MWAA/readme.md
@@ -70,6 +70,8 @@ This script requires permission to the following API calls:
 - [iam:ListAttachedRolePolicies](https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListAttachedRolePolicies.html)
 - [iam:GetPolicy](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetPolicy.html)
 - [iam:GetPolicyVersion](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetPolicyVersion.html)
+- [iam:ListRolePolicies](https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListRolePolicies.html)
+- [iam:GetRolePolicy](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetRolePolicy.html)
 - [iam:SimulateCustomPolicy](https://docs.aws.amazon.com/IAM/latest/APIReference/API_SimulateCustomPolicy.html)
 
 ### example usage:

--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -146,6 +146,17 @@ def get_enis(input_subnet_ids, vpc, security_groups):
     return enis
 
 
+def get_inline_policies(iam_client, role_arn):
+    """
+    Get inline policies in for a role
+    """
+    inline_policies = iam_client.list_role_policies(RoleName=role_arn)
+    return [
+            json.dumps(iam_client.get_role_policy(RoleName=role_arn, PolicyName=policy).get("PolicyDocument", ))
+            for policy in inline_policies.get("PolicyNames", [])
+    ]
+
+
 def check_iam_permissions(input_env, iam_client):
     '''uses iam simulation to check permissions of the role assigned to the environment'''
     print('### Checking the IAM execution role', input_env['ExecutionRoleArn'], 'using iam policy simulation')
@@ -161,6 +172,8 @@ def check_iam_permissions(input_env, iam_client):
                                                    VersionId=policy_version)['PolicyVersion']['Document']
         policy_list.append(json.dumps(policy_doc))
     eval_results = []
+    # Add inline policies
+    policy_list.extend(get_inline_policies(iam_client, input_env['ExecutionRoleArn'].split("/")[-1]))
     if "KmsKey" in input_env:
         print('Found Customer managed CMK')
         eval_results = eval_results + iam_client.simulate_custom_policy(


### PR DESCRIPTION
*Issue #, if available:*

Adding logic to include inline policies on MWAA role

*Description of changes:*

- Added a function to retrieve  the inline policies and passed it to the Policy Simulator. 
- Updated readme to reflect the additional IAM policies needed to get the inline policy  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
