### PR TITLE
Update to reflect changes to mwaa service S3 public access block verification

### DIFF
--- a/MWAA/readme.md
+++ b/MWAA/readme.md
@@ -195,5 +195,12 @@ Found the following failing logs in cloudwatch:
 
 ### Development
 
+#### Dependencies
+The unit tests depend on the following Python modules, please install them with pip3 before proceeding:
+- [pytest](https://docs.pytest.org/en/stable/usage.html#calling-pytest-through-python-m-pytest) a unit testing framework.
+- [moto mock](http://docs.getmoto.org/en/latest/) a library for mocking the APIs of AWS services.
+
 #### Unit tests
-run the unit tests using the command [`python3 -m pytest`](https://docs.pytest.org/en/stable/usage.html#calling-pytest-through-python-m-pytest)
+Run the unit tests using the command: `MOTO_ACCOUNT_ID=123456789123 python3 -m pytest`
+
+Note: the account id above is used to create a "virtual" Moto account. It can be any id, but one *must* be provided.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
#### Summary:
- MWAA service now allows S3 public access block to be configured on the
account or the bucket, instead of only the bucket level.
- Update the verify_env script to validate with the same behaviour.
- Add unit tests to cover the S3 public access validation code.
- Update readme to reflect changes to testing dependencies and execution
command.
- Correctly handles cases where config is not even set.


#### Testing:
All unit tests pass.

Some example UAT tests:

An example of the verify script running on a MWAA env where public access on the bucket is NOT blocked, however access is blocked at the account level:
```
### Verifying 'block public access' is enabled on the s3 bucket or account...
Checking if public access is blocked at the bucket level
Checking if public access is blocked at the account level
s3 bucket, arn:aws:s3:::onikolas-ohio-mwaa, or account blocks public access ✅
```
An example of the verify script running on a MWAA env where public access on the bucket is blocked:
```
### Verifying 'block public access' is enabled on the s3 bucket or account...
Checking if public access is blocked at the bucket level
Checking if public access is blocked at the account level
s3 bucket, arn:aws:s3:::onikolas-ohio-mwaa, or account blocks public access ✅
```
An example of the verify script running on a MWAA env where the bucket level public access block is not even set, however access is blocked at the account level:
```
### Verifying 'block public access' is enabled on the s3 bucket or account...
Checking if public access is blocked at the bucket level
The bucket level access block config is not set
Checking if public access is blocked at the account level
s3 bucket, arn:aws:s3:::onikolas-ohio-mwaa, or account blocks public access ✅
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
