### PR TITLE
Fixing MWAA environment KMS policy test 

### DIFF
--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -428,7 +428,7 @@ def check_iam_permissions(input_env, iam_client):
                 "kms:Encrypt"
             ],
             ResourceArns=[
-                "arn:aws:kms:*:111122223333:key/*"
+                "arn:aws:kms:*:" + account_id + ":key/*"
             ],
             ContextEntries=[
                 {
@@ -446,7 +446,7 @@ def check_iam_permissions(input_env, iam_client):
                 "kms:GenerateDataKey*"
             ],
             ResourceArns=[
-                "arn:aws:kms:*:111122223333:key/*"
+                "arn:aws:kms:*:" + account_id + ":key/*"
             ],
             ContextEntries=[
                 {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The MWAA test script is currently using the account ID from the README in the actual test instead of the current account ID. This PR switches from using the sample account ID in the policy test to the actual account ID used by other policy checks. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
