### PR TITLE
MWAA: Accept hyphen on profile regex validation

### DIFF
--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -88,7 +88,7 @@ def validation_profile(profile_name):
     '''
     verify profile name doesn't have path to files or unexpected input
     '''
-    if re.match(r"^[a-zA-Z0-9]*$", profile_name):
+    if re.match(r"^[a-zA-Z0-9-\-]*$", profile_name):
         return profile_name
     raise argparse.ArgumentTypeError("%s is an invalid profile name value" % profile_name)
 


### PR DESCRIPTION
Issue https://github.com/awslabs/aws-support-tools/issues/171


Description of changes:  aws profiles may contain hyphens.

Adding ` \-` to matches the hyphen character literally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

