### PR TITLE
Added check for MWAA WebServerAccessMode

### DIFF
--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -494,7 +494,7 @@ def prompt_user_and_print_info(input_env_name, ec2_client):
     )['Environment']
     network_subnet_ids = environment['NetworkConfiguration']['SubnetIds']
     network_subnets = ec2_client.describe_subnets(SubnetIds=network_subnet_ids)['Subnets']
-    WebserverAccessMode = ['Environment']['WebserverAccessMode']
+    WebserverAccessMode = environment['Environment']['WebserverAccessMode']
     for key in environment.keys():
         print(key, ': ', environment[key])
     print('VPC: ', network_subnets[0]['VpcId'], "\n")


### PR DESCRIPTION
MWAA can be deployed in Private Mode Only, this should be checked as well to make sure we have proper VPC endpoints added. NAT Gateway check is not enough, as a customer may have a NAT, but still deploy in Private Mode.

*Issue #, if available:*

*Description of changes:*
Added support for WebServerAccessMode Check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
