### PR TITLE
Update customer messaging for 'stuck' Lambda ENIs to reflect expected…

### DIFF
--- a/Lambda/FindEniMappings/findEniAssociations
+++ b/Lambda/FindEniMappings/findEniAssociations
@@ -109,7 +109,7 @@ then
       echo "$each" | jq -r '.Arn'
     done
   else
-    printf "\nNo manual changes to the ENI found. If this ENI is not deleted automatically in the next 24 hours then it may be 'stuck'. If the ENI will not allow you to delete it manually after 24 hours then please contact AWS support and send them the output of this script.\n"
+    printf "\nNo manual changes to the ENI found. ENIs may take up to 20 minutes to be deleted. If this ENI is not deleted automatically in the next 24 hours then it may be 'stuck'. If IAM roles associated with a VPC Lambda function are deleted before the ENI is deleted, Lambda will not be able to complete the clean-up of the ENI. If the ENI will not allow you to delete it manually after 24 hours then please contact AWS support and send them the output of this script.\n"
   fi
 else
   printf "\nThe following function version(s) use the same subnet and security groups as "${ENI}". They will need to be disassociated/deleted before Lambda will clean up this ENI:\n"


### PR DESCRIPTION
… 20min wait time

*Issue #, if available:*

N/A

*Description of changes:*

Update customer messaging for stuck ENIs associated with Lambda functions. ENIs may take up to 20 minutes to be deleted under normal operations. Lambda uses the IAM role associated with the VPC function to delete ENIs. If the IAM role is deleted before Lambda can delete the ENI, ENI deletion by Lambda will not be possible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
