### PR TITLE
lowercase REGION so that copy paste of link works

### DIFF
--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -879,7 +879,7 @@ def check_connectivity_to_dep_services(input_env, input_subnets, ec2_client, ssm
                           interface_ip, "and", service['service'], "on port", service['port'])
                     print("Please follow this link to view the results of the test:")
                     print("https://console.aws.amazon.com/systems-manager/automation/execution/" + ssm_execution_id +
-                          "?REGION=" + REGION + "\n")
+                          "?region=" + REGION + "\n")
                     break
             except ClientError as client_error:
                 print('Attempt', i, 'Encountered error', client_error.response['Error']['Message'], ' retrying...')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
the URL generated by the python script has region capitalised. This does not yield a valid URL with copy-paste. Lowercase region does work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
