### PR TITLE
Paginate ListFunctions calls to ensure all functions are found

### DIFF
--- a/Lambda/FindEniMappings/findEniAssociations
+++ b/Lambda/FindEniMappings/findEniAssociations
@@ -66,11 +66,17 @@ echo "Found "${ENI}" with "$Subnet" using Security Groups" ${SortedSGs[@]}
 echo "Searching for Lambda function versions using "$Subnet" and Security Groups" ${SortedSGs[@]}"..."
 
 # Get all the Lambda functions in an account that are using the same subnet, including versions
-Response="$(aws lambda list-functions --function-version ALL --region ${REGION} --output json --query 'Functions[?VpcConfig!=`null` && VpcConfig.SubnetIds!=`[]`] | [].{Arn:FunctionArn, Subnets:VpcConfig.SubnetIds, SecurityGroups: VpcConfig.SecurityGroupIds} | [?contains(Subnets, `'$Subnet'`) == `true`]')"
 Functions=()
-for row in $(echo $Response | jq -c -r '.[]')
-do
-  Functions+=(${row})
+Response="$(aws lambda list-functions --function-version ALL --max-items 1000 --region ${REGION} --output json --query '{"NextToken": NextToken, "VpcConfigsByFunction": Functions[?VpcConfig!=`null` && VpcConfig.SubnetIds!=`[]`] | [].{Arn:FunctionArn, Subnets:VpcConfig.SubnetIds, SecurityGroups: VpcConfig.SecurityGroupIds} | [?contains(Subnets, `'$Subnet'`) == `true`] }')"
+# Find functions using the same subnet and security group as target ENI. Use paginated calls to enumerate all functions.
+while : ; do
+    NextToken=$(echo $Response | jq '.NextToken')
+    for row in $(echo $Response | jq -c -r '.VpcConfigsByFunction[]')
+    do
+        Functions+=(${row})
+    done
+    [[ $NextToken != "null" ]] || break
+    Response="$(aws lambda list-functions --function-version ALL --max-items 1000 --starting-token $NextToken --region ${REGION} --output json --query '{"NextToken": NextToken, "VpcConfigsByFunction": Functions[?VpcConfig!=`null` && VpcConfig.SubnetIds!=`[]`] | [].{Arn:FunctionArn, Subnets:VpcConfig.SubnetIds, SecurityGroups: VpcConfig.SecurityGroupIds} | [?contains(Subnets, `'$Subnet'`) == `true`] }')"
 done
 # check if we got any functions with this subnet at all
 if [ $(echo "${#Functions[@]}") -eq 0 ]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Existing script is expecting that list-functions cli will return all functions under the account. However, the cli may perform return partial results and include a NextToken to retrieve the next set of functions. This means that users may not be finding all functions and function versions when trying to identify whether an ENI is still in use.

This change pulls out the NextToken from the response and makes paginated calls until no valid NextToken is returned.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
