### PR TITLE
Various fixes for MWAA verify_env.py script

### DIFF
--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -88,7 +88,7 @@ def validation_profile(profile_name):
     '''
     verify profile name doesn't have path to files or unexpected input
     '''
-    if re.match(r"^[a-zA-Z0-9]*$", profile_name):
+    if re.match(r"^[a-zA-Z0-9_-]*$", profile_name):
         return profile_name
     raise argparse.ArgumentTypeError("%s is an invalid profile name value" % profile_name)
 
@@ -428,7 +428,7 @@ def check_iam_permissions(input_env, iam_client):
                 "kms:Encrypt"
             ],
             ResourceArns=[
-                "arn:aws:kms:*:111122223333:key/*"
+                "arn:aws:kms:*:" + account_id + ":key/*"
             ],
             ContextEntries=[
                 {
@@ -446,7 +446,7 @@ def check_iam_permissions(input_env, iam_client):
                 "kms:GenerateDataKey*"
             ],
             ResourceArns=[
-                "arn:aws:kms:*:111122223333:key/*"
+                "arn:aws:kms:*:" + account_id + ":key/*"
             ],
             ContextEntries=[
                 {
@@ -580,13 +580,13 @@ def check_egress_acls(acls, dst_port):
     '''
     for acl in acls:
         # check ipv4 acl rule only
-        if acl.get('CidrBlock'):
+        if acl.get('CidrBlock') and acl.get('Protocol') != '1':
             # Check Port
             if ((acl.get('Protocol') == '-1') or
                (dst_port in range(acl['PortRange']['From'], acl['PortRange']['To'] + 1))):
                 # Check Action
                 return acl['RuleAction'] == 'allow'
-    return ""
+    return False
 
 
 def check_ingress_acls(acls, src_port_from, src_port_to):
@@ -595,15 +595,15 @@ def check_ingress_acls(acls, src_port_from, src_port_to):
     '''
     for acl in acls:
         # check ipv4 acl rule only
-        if acl.get('CidrBlock'):
+        if acl.get('CidrBlock') and acl.get('Protocol') != '1':
             # Check Port
-            test_range = range(src_port_from, src_port_to)
+            test_range = range(src_port_from, src_port_to + 1)
             set_test_range = set(test_range)
             if ((acl.get('Protocol') == '-1') or
                set_test_range.issubset(range(acl['PortRange']['From'], acl['PortRange']['To'] + 1))):
                 # Check Action
                 return acl['RuleAction'] == 'allow'
-    return ""
+    return False
 
 
 def check_nacl(input_subnets, input_subnet_ids, ec2_client):
@@ -879,7 +879,7 @@ def check_connectivity_to_dep_services(input_env, input_subnets, ec2_client, ssm
                           interface_ip, "and", service['service'], "on port", service['port'])
                     print("Please follow this link to view the results of the test:")
                     print("https://console.aws.amazon.com/systems-manager/automation/execution/" + ssm_execution_id +
-                          "?REGION=" + REGION + "\n")
+                          "?region=" + REGION + "\n")
                     break
             except ClientError as client_error:
                 print('Attempt', i, 'Encountered error', client_error.response['Error']['Message'], ' retrying...')

--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -88,7 +88,7 @@ def validation_profile(profile_name):
     '''
     verify profile name doesn't have path to files or unexpected input
     '''
-    if re.match(r"^[a-zA-Z0-9_-]*$", profile_name):
+    if re.match(r"^[a-zA-Z0-9._-]*$", profile_name):
         return profile_name
     raise argparse.ArgumentTypeError("%s is an invalid profile name value" % profile_name)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I was using this verify_env.py script to find issues with my MWAA environment that I brought up and found a few bugs with the script:
- AWS profile names can contain periods, underscores and dashes
- An example AWS account id was hardcoded in the script, instead of using the `account_id` variable
- The security group ACL check should skip over rules that have their protocol set to 1 (ICMP)
- The range of test ports had an off by one bug where the last port was not being included
- The region url query parameter needs to be lowercase for the AWS console to recognize the parameter

And while not technically a bug, I fixed a couple of instances where there was a function could return either a boolean or an empty string. As someone that prefers proper typing, I switched the empty string response to `False`. I can revert this change if you want.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
