### PR TITLE
Improving AWS profile validation in MWAA/verify_env/verify_env.py.

### DIFF
--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -88,7 +88,7 @@ def validation_profile(profile_name):
     '''
     verify profile name doesn't have path to files or unexpected input
     '''
-    if re.match(r"^[a-zA-Z0-9]*$", profile_name):
+    if re.match(r"^[a-zA-Z0-9.-]*$", profile_name):
         return profile_name
     raise argparse.ArgumentTypeError("%s is an invalid profile name value" % profile_name)
 

--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -88,7 +88,7 @@ def validation_profile(profile_name):
     '''
     verify profile name doesn't have path to files or unexpected input
     '''
-    if re.match(r"^[a-zA-Z0-9.-]*$", profile_name):
+    if re.match(r"^[a-zA-Z0-9._-]*$", profile_name):
         return profile_name
     raise argparse.ArgumentTypeError("%s is an invalid profile name value" % profile_name)
 


### PR DESCRIPTION
Valid AWS profile names can contain `-`, `_`, and `.` characters for sure.

*Issue #, if available:*
AWS profile validation in `MWAA/verify_env/verify_env.py` does not like profiles with dots, dashes and underscores in the name.

*Description of changes:*

Adding `-`, `_`, and `.` characters to AWS profile validation regex.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
