### PR TITLE
nitro_check_script.sh configure NVMe io_timeout

### DIFF
--- a/EC2/NitroInstanceChecks/Readme.md
+++ b/EC2/NitroInstanceChecks/Readme.md
@@ -2,6 +2,10 @@ You can use this script to do the pre-requisites checks before changing the inst
 
     - Verify if NVMe module is installed on your instance. If yes then it will verify if it is loaded in the intiramfs image.
 
+    - Analyses GRUB configuration and determines whether the correct NVMe IO timeout has been explicitly configured. It will give you a prompt to ask if you want to regenerate and modify your current grub configuration and insert the appropriate NVMe IO timeout. The original grub configuration will be saved as /etc/default/grub.backup.$(date +%F-%H:%M:%S) for e.g /etc/default/grub.backup.2018-05-01-22:06:05.
+
+    [WARNING: Provide "y" only if you want this script to reconfigure your grub configuration files. If you provide "n" or "No", it will just skip configuring the NVMe IO timeout, and continues with the rest of the script.
+
     - Verify if ENA module is installed on your instance.
 
     - Analyses the “/etc/fstab” and look for the block devices being mounted using device names. It will give you a prompt to ask if you want to regenerate and modify your  current “/etc/fstab” file to replace the device name of each partition with its UUID. The original fstab file will be saved as /etc/fstab.backup.$(date +%F-%H:%M:%S) for e.g /etc/fstab.backup.2018-05-01-22:06:05

--- a/EC2/NitroInstanceChecks/Readme.md
+++ b/EC2/NitroInstanceChecks/Readme.md
@@ -2,7 +2,7 @@ You can use this script to do the pre-requisites checks before changing the inst
 
     - Verify if NVMe module is installed on your instance. If yes then it will verify if it is loaded in the intiramfs image.
 
-    - Analyses GRUB configuration and determines whether the correct NVMe IO timeout has been explicitly configured. It will give you a prompt to ask if you want to regenerate and modify your current grub configuration and insert the appropriate NVMe IO timeout. The original grub configuration will be saved as /etc/default/grub.backup.$(date +%F-%H:%M:%S) for e.g /etc/default/grub.backup.2018-05-01-22:06:05.
+    - Analyses GRUB configuration and determines whether the correct NVMe IO timeout has been explicitly configured. It will give you a prompt to ask if you want to regenerate and modify your current grub configuration and insert the appropriate NVMe IO timeout. Any grub configuration files that are modified will be saved as /path/to/file.backup.$(date +%F-%H:%M:%S) for e.g /etc/default/grub.backup.2018-05-01-22:06:05. The files that are modified depend on your operating system, but the script will tell you which files it's backing up indicating the files that are being modified.
 
     [WARNING: Provide "y" only if you want this script to reconfigure your grub configuration files. If you provide "n" or "No", it will just skip configuring the NVMe IO timeout, and continues with the rest of the script.
 

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -147,8 +147,9 @@ check_nvme_timeout () {
                 echo "Writing changes to grub configuration..."
                 echo -e "\n\n***********************"
                 if [ -f ${grub_default_file} ]; then
+                    # Determine the correct variable to use from /etc/default/grub
                     source ${grub_default_file}
-		    if [ -n ${GRUB_CMDLINE_LINUX_DEFAULT+x} ]; then
+		    if [ -v GRUB_CMDLINE_LINUX_DEFAULT ]; then
                         grub_default_parameter="GRUB_CMDLINE_LINUX_DEFAULT"
                     else
                         grub_default_parameter="GRUB_CMDLINE_LINUX"

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -113,7 +113,7 @@ check_nvme_timeout () {
         # All other Operating Systems need to be checked
         # with nvme_core taking precendence over nvme if it's available
         for module in nvme nvme_core; do
-	    modinfo ${module} 2>&1 >/dev/null
+	    modinfo ${module} >/dev/null 2>&1
             if [ $? -eq 0 ]; then
                 # module is loaded so we can check the io_timeout max size
                 if [[ `modinfo ${module} 2>/dev/null | grep -E 'parm:.*io_timeout:'` =~ (uint) ]]; then

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -83,7 +83,7 @@ check_nvme_timeout () {
     # Check if Operating system is RHEL6, C6, Amazon Linux 1 etc
     # and set the correct path to grub configuration file
     if [ -n "`uname -r 2>/dev/null | grep -Eo '\.(amzn1|el6)\.' 2>/dev/null`" ]; then
-        grub_config_file="/boot/grub/grub.cfg"
+        grub_config_file="/boot/grub/grub.conf"
     fi
 
     # Check if NVMe io_timeout already configured in grub configuration

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -113,8 +113,9 @@ check_nvme_timeout () {
         # All other Operating Systems need to be checked
         # with nvme_core taking precendence over nvme if it's available
         for module in nvme nvme_core; do
-            if [[ `modinfo ${module} 2<&1 >/dev/null` ]]; then
-                # module is loaded
+	    modinfo ${module} 2>&1 >/dev/null
+            if [ $? -eq 0 ]; then
+                # module is loaded so we can check the io_timeout max size
                 if [[ `modinfo -p ${module} 2>/dev/null | grep -E "^io_timeout:"` =~ (uint) ]]; then
                     # module supports io_timeout of 4294967295
                     nvme_module_name="${module}"

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -167,7 +167,7 @@ check_nvme_timeout () {
                 eval ${grub_cmd}
                 # Confirm NVMe timeout has been added to grub configuration
                 # for the running kernel.
-                if [ -n "`eval ${grub_check_cmd}"`" ]; then
+                if [ -n "`eval ${grub_check_cmd}`" ]; then
                     echo -e "\n\nOK     NVMe IO timeout configured in ${grub_config_file}"
                 else
                     echo -e "\n\nFAILED     NVMe IO timeout couldn't be configured in ${grub_config_file}"

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -104,8 +104,12 @@ check_nvme_timeout () {
         nvme_module_name="nvme_core"
         nvme_module_value=${nvme_uint_timeout_value}
     else
-        if [[ -z `modinfo nvme 2>/dev/null` &&
-              -z `modinfo nvme_core 2>/dev/null` ]]; then
+        modinfo nvme >/dev/null 2>&1
+	nvme_module_not_loaded="$?"
+        modinfo nvme_core >/dev/null 2>&1
+	nvme_core_module_not_loaded="$?"
+        if [[ nvme_module_not_loaded -eq 1 &&
+              nvme_core_module_not_loaded -eq 1 ]]; then
             # NVMe modules not installed
             echo -e "\n\nWARNING Neither nvme nor nvme_core kernel modules are loaded."
             return

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -81,9 +81,10 @@ check_nvme_timeout () {
 
     # Check if Operating system is RHEL6, C6, Amazon Linux 1 etc
     # and set the correct path to grub configuration file
-    # These are often soft linked to /boot/grub/grub.conf or /boot/grub/menu.lst
-    if [ -n "`uname -r 2>/dev/null | grep -Eo '\.(amzn1|el6)\.' 2>/dev/null`" ]; then
-        grub_config_file="/etc/grub.conf"
+    if [ -n "`uname -r 2>/dev/null | grep -Eo '\.el6\.' 2>/dev/null`" ]; then
+        grub_config_file="/boot/grub/grub.conf"
+    elif [ -n "`uname -r 2>/dev/null | grep -Eo '\.amzn1\.' 2>/dev/null`" ]; then
+        grub_config_file="/boot/grub/menu.lst"
     fi
 
     # Check if NVMe io_timeout already configured in grub configuration

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -156,7 +156,7 @@ check_nvme_timeout () {
                     echo -e "\nOriginal ${grub_default_file} file is stored as ${grub_default_file}.backup.$time_stamp"
                     sed -i "s/GRUB_CMDLINE_LINUX_DEFAULT=\"/GRUB_CMDLINE_LINUX_DEFAULT=\"${nvme_module_name}.io_timeout=${nvme_module_value} /" ${grub_default_file}
                 fi
-                ${grub_cmd}
+                eval ${grub_cmd}
                 # Confirm NVMe timeout has been added to grub configuration
                 # for the running kernel.
                 if [ -n "`grep -E 'nvme.*\.io_timeout=[0-9]+' ${grub_config_file} | grep "\`uname -r\`"`" ]; then

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -131,7 +131,7 @@ check_nvme_timeout () {
     # Make sure RHEL6 style operating systems use grubby instead of grub2-mkconfig
     if [ -n "`uname -r 2>/dev/null | grep -Eo '\.(amzn1|el6)\.' 2>/dev/null`" ]; then
         grub_cmd="`which grubby 2>/dev/null` --update-kernel=ALL --args=${nvme_module_name}.io_timeout=${nvme_module_value}"
-	grub_check_cmd="grubby --info=ALL | grep -Eo 'nvme.*\.io_timeout=[0-9]+' ${grub_config_file}"
+	grub_check_cmd="grubby --info=ALL | grep -Eo 'nvme.*\.io_timeout=[0-9]+'"
     fi
 
     # Set a default grub command if none has already been specified

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -69,7 +69,7 @@ check_nvme_timeout () {
     time_stamp=$(date +%F-%H:%M:%S)
     grub_default_file="/etc/default/grub"
     grub_config_file="/boot/grub2/grub.cfg"
-    grub_cmd="`which grub2-mkconfig` >${grub_config_file}"
+    grub_cmd="`which grub2-mkconfig 2>/dev/null` >${grub_config_file}"
     nvme_byte_timeout_value=254
     nvme_uint_timeout_value=4294967295
 
@@ -77,7 +77,7 @@ check_nvme_timeout () {
     # and also use a different grub configuration file
     if [ -f /etc/debian_version ]; then
 	grub_config_file="/boot/grub/grub.cfg"
-        grub_cmd="`which grub-mkconfig` >${grub_config_file}"
+        grub_cmd="`which grub-mkconfig 2>/dev/null` >${grub_config_file}"
     fi
 
     # Check if Operating system is derived from RHEL6 such as
@@ -87,7 +87,7 @@ check_nvme_timeout () {
     # because grub2-mkconfig and grub-mkconfig aren't available
     if [ -n "`uname -r 2>/dev/null | grep -Eo '\.(amzn1|el6)\.' 2>/dev/null`" ]; then
         grub_config_file="/boot/grub/grub.cfg"
-        grub_cmd="`which grubby` --update-kernel=ALL --args=\"${nvme_module_name}.io_timeout=${nvme_module_value}\""
+        grub_cmd="`which grubby 2>/dev/null` --update-kernel=ALL --args=\"${nvme_module_name}.io_timeout=${nvme_module_value}\""
     fi
 
     # Check if NVMe io_timeout already configured in grub configuration

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -116,7 +116,7 @@ check_nvme_timeout () {
 	    modinfo ${module} 2>&1 >/dev/null
             if [ $? -eq 0 ]; then
                 # module is loaded so we can check the io_timeout max size
-                if [[ `modinfo -p ${module} 2>/dev/null | grep -E "^io_timeout:"` =~ (uint) ]]; then
+                if [[ `modinfo ${module} 2>/dev/null | grep -E 'parm:.*io_timeout:'` =~ (uint) ]]; then
                     # module supports io_timeout of 4294967295
                     nvme_module_name="${module}"
                     nvme_module_value=${nvme_uint_timeout_value}

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -81,8 +81,9 @@ check_nvme_timeout () {
 
     # Check if Operating system is RHEL6, C6, Amazon Linux 1 etc
     # and set the correct path to grub configuration file
+    # These are often soft linked to /boot/grub/grub.conf or /boot/grub/menu.lst
     if [ -n "`uname -r 2>/dev/null | grep -Eo '\.(amzn1|el6)\.' 2>/dev/null`" ]; then
-        grub_config_file="/boot/grub/grub.conf"
+        grub_config_file="/etc/grub.conf"
     fi
 
     # Check if NVMe io_timeout already configured in grub configuration

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -19,8 +19,8 @@ check_NVMe_in_initrd () {
 find_distro=`cat /etc/os-release |sed -n 's|^ID="\([a-z]\{4\}\).*|\1|p'`      # Check if instance is using amazon AMI. 
 
     if [ -f /etc/redhat-release ] ; then
-        # Distribution is Red hat
-        lsinitrd /boot/initramfs-$(uname -r).img|grep nvme > /dev/null 2>&1
+        # Distribution is Red hat or a Red hat derivative such CentOS or Oracle Linux
+        lsinitrd /boot/initramfs-$(uname -r).img|grep nvme.ko > /dev/null 2>&1
         if [ $? -ne 0 ]; then
         # NVMe module is not loaded in initrd/initramfs
         echo -e "\n\nERROR  NVMe Module is not loaded in the initramfs image.\n\t- Please run the following command on your instance to recreate initramfs:"

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -136,9 +136,13 @@ check_nvme_timeout () {
 	grub_check_cmd="grubby --info=ALL | grep -Eo 'nvme.*\.io_timeout=[0-9]+'"
     fi
 
-    # Set a default grub command if none has already been specified
+    # Set a default grub command if none has already been set
     if [ -z "${grub_cmd}" ]; then
         grub_cmd="`which grub2-mkconfig 2>/dev/null` >${grub_config_file}"
+    fi
+
+    # Set a default grub check command if one hasn't already been set
+    if [ -z "${grub_check_cmd}" ]; then
 	grub_check_cmd="grep -Eo 'nvme.*\.io_timeout=[0-9]+' ${grub_config_file}"
     fi
 

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -80,14 +80,10 @@ check_nvme_timeout () {
         grub_cmd="`which grub-mkconfig 2>/dev/null` >${grub_config_file}"
     fi
 
-    # Check if Operating system is derived from RHEL6 such as
-    # Amazon Linux
-    # CentOS 6
-    # Orable Linux 6 etc and use grubby instead 
-    # because grub2-mkconfig and grub-mkconfig aren't available
+    # Check if Operating system is RHEL6, C6, Amazon Linux 1 etc
+    # and set the correct path to grub configuration file
     if [ -n "`uname -r 2>/dev/null | grep -Eo '\.(amzn1|el6)\.' 2>/dev/null`" ]; then
         grub_config_file="/boot/grub/grub.cfg"
-        grub_cmd="`which grubby 2>/dev/null` --update-kernel=ALL --args=\"${nvme_module_name}.io_timeout=${nvme_module_value}\""
     fi
 
     # Check if NVMe io_timeout already configured in grub configuration
@@ -131,6 +127,11 @@ check_nvme_timeout () {
                 fi
 	    fi
         done
+    fi
+
+    # Make sure RHEL6 style operating systems use grubby instead of grub2-mkconfig
+    if [ -n "`uname -r 2>/dev/null | grep -Eo '\.(amzn1|el6)\.' 2>/dev/null`" ]; then
+        grub_cmd="`which grubby 2>/dev/null` --update-kernel=ALL --args=\"${nvme_module_name}.io_timeout=${nvme_module_value}\""
     fi
 
     echo -e "\n\nWARNING  Your kernel NVMe io_timeout value is not explicitly set. You should set the io_timeout to avoid io timeout issues under Nitro."

--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -147,14 +147,19 @@ check_nvme_timeout () {
                 echo "Writing changes to grub configuration..."
                 echo -e "\n\n***********************"
                 if [ -f ${grub_default_file} ]; then
+                    source ${grub_default_file}
+		    if [ -n ${GRUB_CMDLINE_LINUX_DEFAULT+x} ]; then
+                        grub_default_parameter="GRUB_CMDLINE_LINUX_DEFAULT"
+                    else
+                        grub_default_parameter="GRUB_CMDLINE_LINUX"
+                    fi
                     cp -a ${grub_default_file} ${grub_default_file}.backup.$time_stamp
                     echo -e "\nOriginal ${grub_default_file} file is stored as ${grub_default_file}.backup.$time_stamp"
-                    sed -i "s/GRUB_CMDLINE_LINUX_DEFAULT=\"/GRUB_CMDLINE_LINUX_DEFAULT=\"${nvme_module_name}.io_timeout=${nvme_module_value} /" ${grub_default_file}
+                    sed -i "s/${grub_default_parameter}=\"/${grub_default_parameter}=\"${nvme_module_name}.io_timeout=${nvme_module_value} /" ${grub_default_file}
                 fi
                 if [ -f ${grub_config_file} ]; then
                     cp -a ${grub_config_file} ${grub_config_file}.backup.$time_stamp
-                    echo -e "\nOriginal ${grub_default_file} file is stored as ${grub_default_file}.backup.$time_stamp"
-                    sed -i "s/GRUB_CMDLINE_LINUX_DEFAULT=\"/GRUB_CMDLINE_LINUX_DEFAULT=\"${nvme_module_name}.io_timeout=${nvme_module_value} /" ${grub_default_file}
+                    echo -e "\nOriginal ${grub_config_file} file is stored as ${grub_config_file}.backup.$time_stamp"
                 fi
                 eval ${grub_cmd}
                 # Confirm NVMe timeout has been added to grub configuration


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Update the nitro_check_script.sh bash script to include detection and configuration of nvme io_timeout kernel parameters in accordance with https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes.

By configuring the check directly into the nitro_check_script.sh script, we can avoid nvme-related IO timeout (input/output) errors in future.

Checks and confirms which module is available with nvme_core taking precendence over nvme. io_timeout values are set according to the maximum supported by the parameter.

Uses tools such as grub2-mkconfig, grub-mkconfig, or grubby according to the operating system to modify kernel parameters.

Backs up any files that are modified ie /etc/default/grub, /boot/grub2/grub.cfg etc as /path/to/file.backup.$time_stamp to allow user to rollback any changes.

Tested against:

Debian 10
Debian 11
Ubuntu 14.04
Ubuntu 16.04
Ubuntu 18.04
Ubuntu 20.04
CentOS 6.10
CentOS 7.9
RHEL 6.10
RHEL 7.7
RHEL 8.2
Oracle Linux 7.5
SLES 12
SLES 15
AL1
AL2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
