### PR TITLE
Update for compatibility with Windows GitBash

### DIFF
--- a/Lambda/FindEniMappings/findEniAssociations
+++ b/Lambda/FindEniMappings/findEniAssociations
@@ -53,17 +53,19 @@ fi
 # search for the ENI to get the subnet and security group(s) it uses
 METADATA="$(aws ec2 describe-network-interfaces --network-interface-ids ${ENI} --filters Name=network-interface-id,Values=${ENI} --region ${REGION} --output json --query 'NetworkInterfaces[0].{Subnet:SubnetId,SecurityGroups:Groups[*].GroupId}')"
 
-read Subnet < <(echo $METADATA | jq -r '.Subnet')
+read Subnet < <(echo $METADATA | jq -ar '.Subnet')
 SecurityGroups=()
-for row in $(echo $METADATA | jq -r '.SecurityGroups[]')
+for row in $(echo $METADATA | jq -ar '.SecurityGroups[]')
 do
   SecurityGroups+=(${row})
 done
 # Sort the list of SGs, so that we can easily compare with the list from a Lambda function
 IFS=$'\n' SortedSGs=($(sort <<<"${SecurityGroups[*]}"))
 unset IFS
-echo "Found "${ENI}" with "$Subnet" using Security Groups" ${SortedSGs[@]}
-echo "Searching for Lambda function versions using "$Subnet" and Security Groups" ${SortedSGs[@]}"..."
+#convert Subnet to "echo-able", if $Subnet is used directly, GitBash skips the call outputting: ' using Security Groups "sg-012345example" '
+SUBNET_STRING=$(echo $Subnet)
+echo "Found "${ENI}" with $SUBNET_STRING using Security Groups" ${SortedSGs[@]}
+echo "Searching for Lambda function versions using "$SUBNET_STRING" and Security Groups" ${SortedSGs[@]}"..."
 
 # Get all the Lambda functions in an account that are using the same subnet, including versions
 Functions=()
@@ -89,7 +91,7 @@ for each in "${Functions[@]}"
 do
   # Check if there are any functions that match the security groups of the ENI
   LambdaSGs=()
-  for row in $(echo "$each" | jq -r '.SecurityGroups[]')
+  for row in $(echo "$each" | jq -ar '.SecurityGroups[]')
   do
     LambdaSGs+=(${row})
   done


### PR DESCRIPTION
This proposal is based on a customer case which revealed a bug when running this script in GitBash on Windows.

Please see how the query fails in GitBash on Windows:
```
$ ./findEniAssociations --eni "eni-0c9f62047560173ee" --region "us-east-1" This script is for determining why an ENI that is managed by AWS Lambda has not been deleted.

 using Security Groups sg-08fa5776048baa8ccc57c3be6142316
 and Security Groups sg-08fa5776048baa8cc... subnet-082c57c3be6142316

Bad value for --query {"NextToken": NextToken, "VpcConfigsByFunction": Functions[?VpcConfig!=`null` && VpcConfig.SubnetIds!=`[]`] | [].{Arn:FunctionArn, Subnets:VpcConfig.SubnetIds, SecurityGroups: VpcC:) == `true`] }: Bad jmespath expression: Bad token subnet-082c57c3be6142316 {"NextToken": NextToken, "VpcConfigsByFunction": Functions[?VpcConfig!=`null` && VpcConfig.SubnetIds!=`[]`] | [].{Arn:FunctionArn, Subnets:VpcConfig.SubnetIds, SecurityGroups: VpcConfig.SecurityGroupIds`) == `true`] }Subnets, `subnet-082c57c3be6142316
```
The proposed changes are two-fold:
1. Includes the -a option (or --ascii-output) on 3 of the jq commands. The -a option forces jq to produce pure ASCII, which remediates an issue due to how different operating systems interpret newlines and escape sequences[1][2].
2. Uses a variable SUBNET_STRING to hold the value of the subnet(s), the format of which was causing an issue for the same reason.

This updated version has been tested by me on Windows_Server-2022-English-Full-Base-2022.12.14, Amazon Linux 2 AMI, and Apple M1 MacBook.

[1] https://stedolan.github.io/jq/manual/
[2] https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/#:~:text=Whereas%20Windows%20follows%20the%20original,the%20era%20of%20the%20typewriter.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
