### PR TITLE
Fix profile validation

### DIFF
--- a/MWAA/tests/test_verify_env.py
+++ b/MWAA/tests/test_verify_env.py
@@ -97,7 +97,7 @@ def test_validate_envname():
 
 def test_validate_profile():
     '''
-    test invalid and valid names for MWAA environment
+    test invalid and valid names for the profile
     '''
     with pytest.raises(argparse.ArgumentTypeError) as excinfo:
         profile_name = 'test space'
@@ -113,6 +113,12 @@ def test_validate_profile():
     result = verify_env.validation_profile(profile_name)
     assert result == profile_name
     profile_name = 'HelloWorld'
+    result = verify_env.validation_profile(profile_name)
+    assert result == profile_name
+    profile_name = '_HelloWorld'
+    result = verify_env.validation_profile(profile_name)
+    assert result == profile_name
+    profile_name = 'Hello-World'
     result = verify_env.validation_profile(profile_name)
     assert result == profile_name
 

--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -88,7 +88,7 @@ def validation_profile(profile_name):
     '''
     verify profile name doesn't have path to files or unexpected input
     '''
-    if re.match(r"^[a-zA-Z0-9]*$", profile_name):
+    if re.match(r"^[a-zA-Z0-9-_]*$", profile_name):
         return profile_name
     raise argparse.ArgumentTypeError("%s is an invalid profile name value" % profile_name)
 


### PR DESCRIPTION
*Description of changes:*
- Correct the validation for the profile 
  > You can use letters, numbers, hyphens ( - ), and underscores ( _ ), but no spaces.
- Added additional profile name validation alternatives to the tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
