### PR TITLE
Update MWAA verify_env.py to support new partitions

### DIFF
--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -78,7 +78,8 @@ def validation_region(input_region):
     REGION: example is us-east-1
     '''
     session = Session()
-    mwaa_regions = session.get_available_regions('mwaa')
+    partition = session.get_partition_for_region(input_region)
+    mwaa_regions = session.get_available_regions('mwaa', partition)
     if input_region in mwaa_regions:
         return input_region
     raise argparse.ArgumentTypeError("%s is an invalid REGION value" % input_region)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

MWAA Launched in China regions BJS and ZHY in mid May 2023. But this helper script doesn't work properly because if the region is specified to china, we will get `Invalid Region exception`. The issue was that china regions are not returned in the call to `get_available_regions`. From the [implementation](https://github.com/boto/botocore/blob/a3c3628cbc7f222a94fbbbf3c478a80198876531/botocore/session.py#L1062-L1063) of that function, we can see that `partition_name='aws'` is the default value, and we need to specify a partition for China `aws-cn`. We can use `get_partition_for_region` to get the correct partition for each region input, and then this script can work normally.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
