### PR TITLE
Two optimizations on the MWAA verify env script: 1. support run on cloudshell directly 2. support "output" argument to save to file

### DIFF
--- a/MWAA/readme.md
+++ b/MWAA/readme.md
@@ -21,16 +21,9 @@ This script may identify why.
 ```
 pip3 install boto3 --upgrade --user
 git clone https://github.com/awslabs/aws-support-tools.git
-python3 aws-support-tools/MWAA/verify_env/verify_env.py --envname YOUR_ENV_NAME_HERE
+python3 aws-support-tools/MWAA/verify_env/verify_env.py --envname YOUR_ENV_NAME_HERE --output /tmp/verify_output.txt
 ```
-
-#### How can I send the output to a file automatically?
-
-##### Use a redirection operator
-python3 aws-support-tools/MWAA/verify_env/verify_env.py --envname YOUR_ENV_NAME_HERE > output.log
-
-##### Use vscode or codium
-python3 aws-support-tools/MWAA/verify_env/verify_env.py --envname YOUR_ENV_NAME_HERE | code -
+The above script is recommended to run on [AWS CloudShell](console.aws.amazon.com/cloudshell). Script is expected to run for minutes. Output file can be downloaded from "Actions > Download file" at top right of CloudShell page.
 
 ### Logic and api calls
 The following actions will be performed in this order:
@@ -86,6 +79,7 @@ optional arguments:
   --envname ENVNAME  name of the MWAA environment
   --region REGION    region, Ex: us-east-1
   --profile PROFILE  profile, Ex: dev
+  --output OUTPUT    output file path, Ex: /tmp/output.txt
 ```
 
 ### example output:


### PR DESCRIPTION

*Description of changes:*
1. Support run script on CloudShell directly( Remove "default profile" when not specifying "profile" argument, so boto3 can use instance role directly. And do not have to setup profile file)
2. Add output argument to save to file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
