### PR TITLE
Fix MWAA verify env script None object

### DIFF
--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -655,7 +655,7 @@ def check_service_vpc_endpoints(ec2_client, subnets):
     '''
     should be used if the environment does not have internet access through NAT Gateway
     '''
-    top_level_domain = TOP_LEVEL_DOMAIN.split(".").reverse().join(".")
+    top_level_domain = ".".join(reversed(TOP_LEVEL_DOMAIN.split(".")))
     service_endpoints = [
         top_level_domain + REGION + '.airflow.api',
         top_level_domain + REGION + '.airflow.env',


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/aws-support-tools/issues/220

*Description of changes:*
There is issue with code:
```
top_level_domain = TOP_LEVEL_DOMAIN.split(".").reverse().join(".")
```
AttributeError: ‘NoneType’ object has no attribute ‘join’
.reverse() will not return anything, so .join() won’t work, changing it to the correct syntax.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
