### PR TITLE
MWAA regex improvement for validating profiles

### DIFF
--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -89,7 +89,7 @@ def validation_profile(profile_name):
     '''
     verify profile name doesn't have path to files or unexpected input
     '''
-    if re.match(r"^[a-zA-Z0-9]*$", profile_name):
+    if re.match(r"^[a-zA-Z0-9-_]*$", profile_name):
         return profile_name
     raise argparse.ArgumentTypeError("%s is an invalid profile name value" % profile_name)
 


### PR DESCRIPTION
Adding underscore and hyphen to the profile name regex. This is based on the regex present in `validate_envname`.

Note there is a related pull request here: https://github.com/awslabs/aws-support-tools/pull/223

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


