### PR TITLE
Improve `curl_for_latency.sh` by re-using a TCP connection between requests, removing the noise and delay of the initial connection to better simulate a real-life use case.

### DIFF
--- a/APIGateway/Tools/curl_for_latency/README.md
+++ b/APIGateway/Tools/curl_for_latency/README.md
@@ -1,14 +1,28 @@
 # curl_for_latency
 
-*Bash script for checking latency when communicating with API Gateway through CloudFront.*
+_Bash script for checking latency when communicating with API Gateway through CloudFront._
 
-----
+---
 
-This script will execute three (3) requests to the endpoint at two (2) second intervals.  The results show the total time taken for the request and response, and the time for each step.  Descriptions are included for what is occurring.
+This script will execute three (3) requests to the endpoint at two (2) second intervals. The results show the total time taken for the request and response, and the time for each step. Descriptions are included for what is occurring.
+
+The initial request will take the longest, after which time the `time_connect` and `time_appconnect` will be 0 as a TCP connection is re-used between requests.
 
 ## Requirements
 
-* The script `curl_for_latency.sh` requires the following modifications.
-  * Replace the `method` and `URL` in the curl command
-    * *-X `GET` `"https://1234567890.execute-api.us-west-2.amazonaws.com/stage/resource?nocaching=$(uuidgen)"`*
-  * Optional: Add custom headers by including them below the verbose option `-v` as `-H 'header-key:value'`
+### The script `curl_for_latency.sh` requires the following arguments.
+
+You will need to supply the request method and URL:
+
+```
+./curl_for_latency.sh GET https://1234567890.execute-api.us-west-2.amazonaws.com/stage/resource
+```
+
+### The script `curl_for_latency.sh` may require some modifications, dependant on your API configuration.
+
+There are various parameters you may want to change on this example script:
+
+- The request method from POST to GET
+- Removing (or adjusting) the 2 second interval between requests by altering the `--rate 30/m` argument
+- Adding cache-busting query strings to each request. You may consider adding `?nocaching=$(uuidgen)` into the URLs that are called by doing `-X POST "$2?nocaching=$(uuidgen)" "$2?nocaching=$(uuidgen)" "$2?nocaching=$(uuidgen)"`
+- Adding custom authentication headers by including them below the verbose option `-v` as `-H 'header-key:value'`

--- a/APIGateway/Tools/curl_for_latency/curl_for_latency.sh
+++ b/APIGateway/Tools/curl_for_latency/curl_for_latency.sh
@@ -41,17 +41,10 @@ EOV
 
 
 # Execute the curl command
-# NOTE: The URL and curl options should be modified to suit your needs, including adding headers (API keys, Authorization tokens, etc.)
-# The query string "nocaching=$(uuidgen)" is automatically populated with a random UUID.  This can be used to prevent caching of the requests.
-x=1
-while (( x <= 3 )); do
-    sleep 2
-    echo "\n-----------------------------------\n"
-    curl \
-    -w "$TIME_DATA" \
-    -o /dev/null \
-    -s \
-    -v \
-    -X GET "https://1234567890.execute-api.us-west-2.amazonaws.com/stage/resource?nocaching=$(uuidgen)"
-    ((x++))
-done
+curl \
+   --rate 30/m \
+   -w "$TIME_DATA" \
+   -o /dev/null \
+   -s \
+   -v \
+   -X $1 "$2" "$2" "$2"


### PR DESCRIPTION
*Case number:* `13875838791`

*Description of changes:*

In a "real life" example where a client would interact with an edge-optimised API, steps 1-3 of [this guide](https://repost.aws/knowledge-center/source-latency-requests-api-gateway) is likely to be cached.

By re-using the TCP connection in this script it better pinpoints the increased latency within the connection between CloudFront and API Gateway.
