### PR TITLE
Update assign_private_ip_v2.py

### DIFF
--- a/EMR/Assign_Private_IP/assign_private_ip_v2.py
+++ b/EMR/Assign_Private_IP/assign_private_ip_v2.py
@@ -38,4 +38,4 @@ if is_master == "true":
     primary_ip = subprocess.check_output(['TOKEN=`/usr/bin/curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && /usr/bin/curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4'], shell=True, universal_newlines=True).strip()
     subprocess.check_call(['sudo iptables -t nat -A PREROUTING -d %s -j DNAT --to-destination %s' % (private_ip, primary_ip)], shell=True)
 else:
-    print "Not the master node"
+    print ("Not the master node")

--- a/EMR/Assign_Private_IP/assign_private_ip_v2.py
+++ b/EMR/Assign_Private_IP/assign_private_ip_v2.py
@@ -13,7 +13,7 @@
 
 import sys, subprocess
 
-is_master = subprocess.check_output(['cat /emr/instance-controller/lib/info/instance.json | jq .isMaster'], shell=True).strip()
+is_master = subprocess.check_output(['cat /emr/instance-controller/lib/info/instance.json | jq .isMaster'], shell=True).decode('utf-8').strip()
 
 if is_master == "true":
     private_ip = str(sys.argv[1])


### PR DESCRIPTION
Changes tested in EMR 7.9.0. Cluster using the original script failed with typo first and then failed to apply due to comparing bytes with string, will always print not the master. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
