### PR TITLE
Fix bugs in MWAA verify_env: S3 client reference and missing json importFix/mwaa verify env

### DIFF
--- a/MWAA/verify_env/airflow_verifier.py
+++ b/MWAA/verify_env/airflow_verifier.py
@@ -283,7 +283,7 @@ class AirflowVerifier:
 
         print("Do you want to delete the dag used for the test?")
         if input("(y/N):").lower().strip() in ["y", "yes"]:
-            self.delete_file_from_dags_folder(self.env, os.path.join(os.path.dirname(os.path.realpath(__file__)), "MWAA_TEST_DAG.py"), s3)
+            self.delete_file_from_dags_folder(self.env, os.path.join(os.path.dirname(os.path.realpath(__file__)), "MWAA_TEST_DAG.py"), self.s3)
             self.report.write_all_locations(f"✅ Test DAG '{dag_id}' is deleted.")
         else:
             self.report.write_all_locations(f"✅ The user selected to keep the test DAG '{dag_id}'.")

--- a/MWAA/verify_env/utils.py
+++ b/MWAA/verify_env/utils.py
@@ -17,6 +17,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 '''
 import argparse
+import json
 import re
 from boto3.session import Session
 


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the MWAA verify_env tool:

1. **Fixed incorrect S3 client reference in `airflow_verifier.py`**: Changed `s3` to `self.s3` in the `delete_file_from_dags_folder` method call (line 286). The previous code would cause a `NameError` when users chose to delete the test DAG after running the full DAG run test.

2. **Added missing `json` import in `utils.py`**: The module uses JSON functionality but was missing the import statement.

## Changes

- [airflow_verifier.py:286](MWAA/verify_env/airflow_verifier.py#L286) - Fixed S3 client parameter from `s3` to `self.s3`
- [utils.py:20](MWAA/verify_env/utils.py#L20) - Added `import json` statement

## Testing

- Verified that the S3 client reference now correctly points to the instance variable
- Confirmed that the json module is properly imported for JSON operations

## Impact

These fixes ensure that:
- The test DAG deletion feature works correctly without throwing NameError
- The utils module has all required imports for its functionality