### PR TITLE
Import json in MWAA utils.py

### DIFF
--- a/MWAA/verify_env/utils.py
+++ b/MWAA/verify_env/utils.py
@@ -17,6 +17,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 '''
 import argparse
+import json
 import re
 from boto3.session import Session
 


### PR DESCRIPTION
Fixes `NameError: name 'json' is not defined`

*Issue #, if available:* https://github.com/awslabs/aws-support-tools/issues/250

*Description of changes:*

Fixes name error

```
### IAM Permissions

Checking the IAM execution role arn:aws:iam::590183657184:role/MwaaExecRole-prod-na-us-east-1 using iam policy simulation

Traceback (most recent call last):
  File "/Users/gaboroca/builds/aws-support-tools/MWAA/verify_env/verify_env.py", line 99, in <module>
    iam_verifier.check_iam_permissions()
  File "/Users/gaboroca/builds/aws-support-tools/MWAA/verify_env/iam_verifier.py", line 51, in check_iam_permissions
    policy_list.extend(get_inline_policies(self.iam, self.env['ExecutionRoleArn'].split("/")[-1]))
  File "/Users/gaboroca/builds/aws-support-tools/MWAA/verify_env/utils.py", line 87, in get_inline_policies
    return [
  File "/Users/gaboroca/builds/aws-support-tools/MWAA/verify_env/utils.py", line 88, in <listcomp>
    json.dumps(iam_client.get_role_policy(RoleName=role_arn, PolicyName=policy).get("PolicyDocument", ))
NameError: name 'json' is not defined
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
