### PR TITLE
fix(EC2/NitroInstanceChecks): use portable os-release detection

### DIFF
--- a/EC2/NitroInstanceChecks/nitro_check_script.sh
+++ b/EC2/NitroInstanceChecks/nitro_check_script.sh
@@ -16,7 +16,15 @@
 
 check_NVMe_in_initrd () {
 
-find_distro=`cat /etc/os-release |sed -n 's|^ID="\([a-z]\{4\}\).*|\1|p'`      # Check if instance is using amazon AMI. 
+    # Detect distro ID from os-release (the standard, portable method).
+    # Sourcing handles both quoted (ID="amzn") and unquoted (ID=ubuntu) values.
+    # Older systems (RHEL 5/6) may lack this file entirely — fall through gracefully.
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        find_distro="$ID"
+    else
+        find_distro=""
+    fi
 
     if [ -f /etc/redhat-release ] ; then
         # Distribution is Red hat or a Red hat derivative such CentOS or Oracle Linux


### PR DESCRIPTION
## Summary

Replaces the fragile one-liner on line 19 of `nitro_check_script.sh` with the standard sourcing pattern recommended by `os-release(5)`.

## Problem

The original code runs `cat /etc/os-release` unconditionally. On systems that lack this file (notably RHEL 5/6), this produces a confusing error:

```
cat: /etc/os-release: No such file or directory
```

Additionally, the sed regex (`s|^ID="\([a-z]\{4\}\).*|\1|p`) only captures exactly 4 lowercase characters after a mandatory double-quote, which silently fails on distros that use unquoted values (e.g. Ubuntu writes `ID=ubuntu`).

## Fix

```bash
if [ -f /etc/os-release ]; then
    . /etc/os-release
    find_distro="$ID"
else
    find_distro=""
fi
```

This:
- Guards against the missing file (fixes the reported error)
- Handles both quoted and unquoted ID values correctly
- Removes the brittle 4-char length assumption
- Follows the POSIX-standard consumption pattern for os-release

The downstream comparisons (`"amzn"`, `"sles"`) remain correct since `$ID` holds those exact strings on Amazon Linux and SUSE.

## Testing

- `bash -n` syntax check passes
- Verified all usages of `find_distro` in the script are compatible with full `$ID` values
- RHEL/CentOS path is handled by the prior `/etc/redhat-release` check (unaffected)
- Debian/Ubuntu path is handled by `/etc/debian_version` check (unaffected)

Closes #124