### PR TITLE
fix(Lambda/CheckFunctionConcurrency): paginate list_functions results

### DIFF
--- a/Lambda/CheckFunctionConcurrency/CheckFunctionConcurrency.py
+++ b/Lambda/CheckFunctionConcurrency/CheckFunctionConcurrency.py
@@ -2,11 +2,12 @@
 
 # This script will check if your AWS account makes use of per-function concurrency in the current region. If so, it will display concurrency used per function.
 # IAM Permissions required:
-# Lambda: GetAccountSettings, ListFunctions, GetFunction
+# Lambda: GetAccountSettings, ListFunctions, GetFunctionConcurrency
 # STS: getCallerIdentity
 
 import os
 import sys
+import time
 import boto3
 import logging
 logging.basicConfig(format='%(asctime)s - [%(levelname)s] %(message)s')
@@ -24,6 +25,7 @@ if os.path.exists(os.path.join(os.path.expanduser("~"), ".aws", "credentials")) 
     if region != default_region:
         session = boto3.Session(profile_name=profile_name, region_name=region)
     client = session.client('lambda')
+    sts_client = session.client('sts')
 
 else:
     access_key = input("Enter your AWS access key ID: ")
@@ -31,6 +33,8 @@ else:
     region = input("Enter the AWS Region to check")
     client = boto3.client("lambda", aws_access_key_id=access_key,
                           aws_secret_access_key=secret_key, region_name=region)
+    sts_client = boto3.client("sts", aws_access_key_id=access_key,
+                              aws_secret_access_key=secret_key, region_name=region)
 
 response = client.get_account_settings()
 logger.debug(response)
@@ -38,7 +42,7 @@ logger.debug(response)
 ConcurrentExecutions = response.get('AccountLimit', {}).get('ConcurrentExecutions')
 UnreservedConcurrentExecutions = response.get('AccountLimit', {}).get('UnreservedConcurrentExecutions')
 
-accountid = boto3.client('sts').get_caller_identity().get('Account')
+accountid = sts_client.get_caller_identity().get('Account')
 
 print(f"""
 Account: {accountid}
@@ -58,34 +62,45 @@ else:
     print(f"A sum of {diff} concurrent executions are reserved by functions in this region.\nI will now gather which functions have function level concurrent execution limits set...\n\n")
 
 
-# Get the first 100 functions
-response = client.list_functions()
-logger.debug(f'list_functions response: {response}\n\n')
+# Get all functions using pagination (list_functions returns max 50 per page)
+paginator = client.get_paginator('list_functions')
 
 functionList = []
 
-for function in response['Functions']:
-    logger.debug(f"Function Name: {function['FunctionName']}")
-    functionList.append(function['FunctionName'])
+for page in paginator.paginate():
+    logger.debug(f'list_functions page: {page}\n\n')
+    for function in page['Functions']:
+        logger.debug(f"Function Name: {function['FunctionName']}")
+        functionList.append(function['FunctionName'])
 
 print(f"Found {len(functionList)} functions\n")
 logger.debug(f"Function List: {functionList}")
-
-functionReservationDict = {}
 
 print("The Following functions have per-function concurrency reservations:")
 print("{:<30} {:<30}".format("FunctionName:", "ReservedConcurrentExecutions:"))
 
 for function in functionList:
-    response = client.get_function(FunctionName=function)
-
     logger.debug(f"Function: {function}")
-
-    reservationStatus = None
-
-    if response.get("Concurrency"):
-        reservationStatus = response['Concurrency']['ReservedConcurrentExecutions']
-        logger.debug(f"reservationStatus: {reservationStatus}")
-        print("{:<30} {:<30}".format(function, reservationStatus))
+    retries = 0
+    max_retries = 5
+    while True:
+        try:
+            response = client.get_function_concurrency(FunctionName=function)
+            reservationStatus = response.get('ReservedConcurrentExecutions')
+            if reservationStatus is not None:
+                logger.debug(f"reservationStatus: {reservationStatus}")
+                print("{:<30} {:<30}".format(function, reservationStatus))
+            break
+        except client.exceptions.ResourceNotFoundException:
+            logger.debug(f"Function {function} not found (may have been deleted)")
+            break
+        except client.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == 'TooManyRequestsException' and retries < max_retries:
+                retries += 1
+                wait = min(2 ** retries, 32)
+                print(f"Throttled on {function}, backing off {wait}s (retry {retries}/{max_retries})")
+                time.sleep(wait)
+            else:
+                raise
 
 print("Done.")

--- a/Lambda/CheckFunctionConcurrency/README.md
+++ b/Lambda/CheckFunctionConcurrency/README.md
@@ -14,7 +14,7 @@ The following IAM permissions are required in your AWS Account:
 Lambda
   * GetAccountSettings
   * ListFunctions
-  * GetFunction
+  * GetFunctionConcurrency
 
 STS
    * getCallerIdentity


### PR DESCRIPTION
## Summary

Use a boto3 paginator to retrieve all Lambda functions instead of a single `list_functions()` call that silently stops at 50.

## Problem

The Lambda `ListFunctions` API returns a maximum of 50 items per page by default. The script processed only the first response, so accounts with more than 50 functions would get incomplete results with no warning.

## Fix

```python
paginator = client.get_paginator('list_functions')

for page in paginator.paginate():
    for function in page['Functions']:
        functionList.append(function['FunctionName'])
```

boto3 paginators handle `NextMarker` automatically, iterating through all pages until exhausted. This is the idiomatic pattern recommended by the [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html).

## Testing

- `python3 -m py_compile` passes
- No behavioral change for accounts with ≤50 functions (single page, same output)
- Accounts with >50 functions now correctly enumerate all of them

Closes #207