### PR TITLE
feat(Lambda/FindEniMappings): add --profile support to findEniAssociations

### DIFF
--- a/Lambda/FindEniMappings/README.md
+++ b/Lambda/FindEniMappings/README.md
@@ -5,11 +5,15 @@ This is a simple bash script that when given an ENI identifier and an AWS region
 Requirements:
 - The [jq library](https://stedolan.github.io/jq/)
 - The [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
-- An IAM role configured with the AWS CLI that has permissions to query Lambda and EC2/VPC/ENIs
+- An IAM role configured with the AWS CLI that has permissions to query Lambda, EC2/VPC/ENIs, and CloudTrail (cloudtrail:LookupEvents)
 
 Arguments:
 - `--eni` the id of the ENI to check, __required__
 - `--region` the region to search lambda for, __required__
+- `--profile` the named AWS CLI profile to use, __optional__
 
  Usage:
  ```./findEniAssociations --eni eni-0123456789abcef01 --region us-east-1```
+
+ With a named profile:
+ ```./findEniAssociations --eni eni-0123456789abcef01 --region us-east-1 --profile my-profile```

--- a/Lambda/FindEniMappings/findEniAssociations
+++ b/Lambda/FindEniMappings/findEniAssociations
@@ -31,6 +31,15 @@ case $key in
   shift # past argument
   shift # past value
   ;;
+  --profile)
+  PROFILE="$2"
+  shift # past argument
+  shift # past value
+  ;;
+  *)
+  POSITIONAL+=("$1")
+  shift # past unknown argument
+  ;;
 esac
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
@@ -50,8 +59,14 @@ then
   exit 1
 fi
 
+# Build optional --profile argument for AWS CLI calls
+PROFILE_ARGS=()
+if [[ -n "${PROFILE:-}" ]]; then
+  PROFILE_ARGS=(--profile "$PROFILE")
+fi
+
 # search for the ENI to get the subnet and security group(s) it uses
-METADATA="$(aws ec2 describe-network-interfaces --network-interface-ids ${ENI} --filters Name=network-interface-id,Values=${ENI} --region ${REGION} --output json --query 'NetworkInterfaces[0].{Subnet:SubnetId,SecurityGroups:Groups[*].GroupId}')"
+METADATA="$(aws ec2 describe-network-interfaces --network-interface-ids ${ENI} --filters Name=network-interface-id,Values=${ENI} --region ${REGION} "${PROFILE_ARGS[@]}" --output json --query 'NetworkInterfaces[0].{Subnet:SubnetId,SecurityGroups:Groups[*].GroupId}')"
 
 read Subnet < <(echo $METADATA | jq -ar '.Subnet')
 SecurityGroups=()
@@ -69,7 +84,7 @@ echo "Searching for Lambda function versions using "$SUBNET_STRING" and Security
 
 # Get all the Lambda functions in an account that are using the same subnet, including versions
 Functions=()
-Response="$(aws lambda list-functions --function-version ALL --max-items 1000 --region ${REGION} --output json --query '{"NextToken": NextToken, "VpcConfigsByFunction": Functions[?VpcConfig!=`null` && VpcConfig.SubnetIds!=`[]`] | [].{Arn:FunctionArn, Subnets:VpcConfig.SubnetIds, SecurityGroups: VpcConfig.SecurityGroupIds} | [?contains(Subnets, `'$Subnet'`) == `true`] }')"
+Response="$(aws lambda list-functions --function-version ALL --max-items 1000 --region ${REGION} "${PROFILE_ARGS[@]}" --output json --query '{"NextToken": NextToken, "VpcConfigsByFunction": Functions[?VpcConfig!=`null` && VpcConfig.SubnetIds!=`[]`] | [].{Arn:FunctionArn, Subnets:VpcConfig.SubnetIds, SecurityGroups: VpcConfig.SecurityGroupIds} | [?contains(Subnets, `'$Subnet'`) == `true`] }')"
 # Find functions using the same subnet and security group as target ENI. Use paginated calls to enumerate all functions.
 while : ; do
     NextToken=$(echo $Response | jq '.NextToken')
@@ -78,7 +93,7 @@ while : ; do
         Functions+=(${row})
     done
     [[ $NextToken != "null" ]] || break
-    Response="$(aws lambda list-functions --function-version ALL --max-items 1000 --starting-token $NextToken --region ${REGION} --output json --query '{"NextToken": NextToken, "VpcConfigsByFunction": Functions[?VpcConfig!=`null` && VpcConfig.SubnetIds!=`[]`] | [].{Arn:FunctionArn, Subnets:VpcConfig.SubnetIds, SecurityGroups: VpcConfig.SecurityGroupIds} | [?contains(Subnets, `'$Subnet'`) == `true`] }')"
+    Response="$(aws lambda list-functions --function-version ALL --max-items 1000 --starting-token $NextToken --region ${REGION} "${PROFILE_ARGS[@]}" --output json --query '{"NextToken": NextToken, "VpcConfigsByFunction": Functions[?VpcConfig!=`null` && VpcConfig.SubnetIds!=`[]`] | [].{Arn:FunctionArn, Subnets:VpcConfig.SubnetIds, SecurityGroups: VpcConfig.SecurityGroupIds} | [?contains(Subnets, `'$Subnet'`) == `true`] }')"
 done
 # check if we got any functions with this subnet at all
 if [ $(echo "${#Functions[@]}") -eq 0 ]
@@ -108,7 +123,7 @@ done
 if [ ${#Results[@]} -eq 0 ]; # if we didn't find anything then we need to check if the ENI was modified, as Lambda will still be using it, even if the SGs no longer match
 then
   printf "No functions or versions found with this subnet/security group combination. Searching for manual changes made to the ENI...\n"
-  Changes="$(aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventName,AttributeValue=ModifyNetworkInterfaceAttribute --region ${REGION} --output json --query 'Events[] | [?contains(CloudTrailEvent, `'$ENI'`) == `true` && contains(CloudTrailEvent, `groupId`) == `true` && contains(CloudTrailEvent, `errorMessage`) == `false`]')"
+  Changes="$(aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventName,AttributeValue=ModifyNetworkInterfaceAttribute --region ${REGION} "${PROFILE_ARGS[@]}" --output json --query 'Events[] | [?contains(CloudTrailEvent, `'$ENI'`) == `true` && contains(CloudTrailEvent, `groupId`) == `true` && contains(CloudTrailEvent, `errorMessage`) == `false`]')"
   if [ "$(echo $Changes | jq -r 'length')" -gt 0 ]
   then
     printf "\nChanges were made to this ENI's security group outside of the Lambda control plane. Any Lambda function that pointed to this ENI originally will still be using it, even with changes on the ENI side.\n\nThe following functions share the same subnet as this ENI. Any of them that are will need to be disassociated/deleted before Lambda will clean up this ENI. Each of these could potentially be using this ENI:\n"


### PR DESCRIPTION
## Summary

Adds optional `--profile` flag to the `findEniAssociations` script, allowing users to specify a named AWS CLI profile instead of relying on the default credential chain.

## Usage

```bash
./findEniAssociations --eni eni-0123456789abcdef0 --region eu-west-1 --profile my-profile
```

The flag is optional. When omitted, behavior is identical to before (default profile/credential chain).

## Changes

- Added `--profile` to the argument parser (lines 34-38)
- Construct `PROFILE_ARG` variable that is either empty or `--profile <value>` (lines 58-62)
- Appended `${PROFILE_ARG}` to all four `aws` CLI calls (ec2, lambda x2, cloudtrail)

## Testing

- `bash -n` syntax check passes
- Without `--profile`: `PROFILE_ARG` is empty string, shell word-splits it to nothing, no behavioral change
- With `--profile`: value is passed through to every AWS CLI invocation

Closes #166