### PR TITLE
fix(MWAA): make --profile optional to support EC2 instance profiles

### DIFF
--- a/MWAA/readme.md
+++ b/MWAA/readme.md
@@ -85,7 +85,8 @@ optional arguments:
   -h, --help         show this help message and exit
   --envname ENVNAME  name of the MWAA environment
   --region REGION    region, Ex: us-east-1
-  --profile PROFILE  profile, Ex: dev
+  --profile PROFILE  AWS CLI profile name (optional). If omitted, uses the
+                     default credential chain (env vars, instance profile, etc.)
 ```
 
 ### example output:

--- a/MWAA/tests/test_aws_clients.py
+++ b/MWAA/tests/test_aws_clients.py
@@ -3,8 +3,6 @@ Tests for AWSClients credential handling.
 Validates that the --profile argument is optional and that
 boto3's default credential chain is used when no profile is specified.
 """
-import boto3
-import pytest
 from unittest.mock import patch, MagicMock
 
 import sys
@@ -46,7 +44,7 @@ class TestAWSClientsProfile:
     def test_all_clients_created(self, mock_setup_session, mock_client):
         """All expected boto3 clients are created regardless of profile setting."""
         mock_client.return_value = MagicMock()
-        clients = AWSClients(region='eu-west-1', profile=None)
+        AWSClients(region='eu-west-1', profile=None)
         expected_services = ['ec2', 's3', 's3control', 'logs', 'kms',
                            'cloudtrail', 'ssm', 'iam', 'mwaa', 'cloudwatch']
         assert mock_client.call_count == len(expected_services)

--- a/MWAA/tests/test_aws_clients.py
+++ b/MWAA/tests/test_aws_clients.py
@@ -1,0 +1,55 @@
+"""
+Tests for AWSClients credential handling.
+Validates that the --profile argument is optional and that
+boto3's default credential chain is used when no profile is specified.
+"""
+import boto3
+import pytest
+from unittest.mock import patch, MagicMock
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'verify_env'))
+
+from aws_clients import AWSClients
+
+
+class TestAWSClientsProfile:
+    """Tests for profile handling in AWSClients."""
+
+    @patch('aws_clients.boto3.client')
+    @patch('aws_clients.boto3.setup_default_session')
+    def test_no_profile_skips_session_setup(self, mock_setup_session, mock_client):
+        """When profile is None, setup_default_session should not be called."""
+        mock_client.return_value = MagicMock()
+        AWSClients(region='us-east-1', profile=None)
+        mock_setup_session.assert_not_called()
+
+    @patch('aws_clients.boto3.client')
+    @patch('aws_clients.boto3.setup_default_session')
+    def test_no_profile_default_arg(self, mock_setup_session, mock_client):
+        """When profile is omitted entirely, setup_default_session should not be called."""
+        mock_client.return_value = MagicMock()
+        AWSClients(region='us-east-1')
+        mock_setup_session.assert_not_called()
+
+    @patch('aws_clients.boto3.client')
+    @patch('aws_clients.boto3.setup_default_session')
+    def test_explicit_profile_sets_session(self, mock_setup_session, mock_client):
+        """When a profile is explicitly provided, setup_default_session is called with it."""
+        mock_client.return_value = MagicMock()
+        AWSClients(region='us-east-1', profile='myprofile')
+        mock_setup_session.assert_called_once_with(profile_name='myprofile')
+
+    @patch('aws_clients.boto3.client')
+    @patch('aws_clients.boto3.setup_default_session')
+    def test_all_clients_created(self, mock_setup_session, mock_client):
+        """All expected boto3 clients are created regardless of profile setting."""
+        mock_client.return_value = MagicMock()
+        clients = AWSClients(region='eu-west-1', profile=None)
+        expected_services = ['ec2', 's3', 's3control', 'logs', 'kms',
+                           'cloudtrail', 'ssm', 'iam', 'mwaa', 'cloudwatch']
+        assert mock_client.call_count == len(expected_services)
+        # Verify each service was requested with the correct region
+        for call in mock_client.call_args_list:
+            assert call[1]['region_name'] == 'eu-west-1'

--- a/MWAA/tests/test_aws_clients.py
+++ b/MWAA/tests/test_aws_clients.py
@@ -1,3 +1,22 @@
+# This Python file uses the following encoding: utf-8
+'''
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+'''
+
 """
 Tests for AWSClients credential handling.
 Validates that the --profile argument is optional and that

--- a/MWAA/verify_env/aws_clients.py
+++ b/MWAA/verify_env/aws_clients.py
@@ -19,8 +19,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 import boto3
 
 class AWSClients:
-    def __init__(self, region, profile='default'):
-        boto3.setup_default_session(profile_name=profile)
+    def __init__(self, region, profile=None):
+        if profile:
+            boto3.setup_default_session(profile_name=profile)
         self.ec2 = boto3.client('ec2', region_name=region)
         self.s3 = boto3.client('s3', region_name=region)
         self.s3control = boto3.client('s3control', region_name=region)

--- a/MWAA/verify_env/verify_env.py
+++ b/MWAA/verify_env/verify_env.py
@@ -73,8 +73,8 @@ if __name__ == '__main__':
     parser.add_argument('--envname', type=validate_envname, required=True, help="name of the MWAA environment")
     parser.add_argument('--region', type=validation_region, default=boto3.session.Session().region_name,
                         required=True, help="region, Ex: us-east-1")
-    parser.add_argument('--profile', type=validation_profile, default='default',
-                        required=False, help="AWS CLI profile, Ex: dev")
+    parser.add_argument('--profile', type=validation_profile, default=None,
+                        required=False, help="AWS CLI profile name (optional). If omitted, uses the default credential chain (env vars, instance profile, etc.)")
     args, _ = parser.parse_known_args()
     ENV_NAME = args.envname
     REGION = args.region


### PR DESCRIPTION
*Issue #, if available:*

Closes #172

*Description of changes:*

Previously, the `--profile` argument defaulted to `'default'`, which caused a `ProfileNotFound` error when running on EC2 instances that rely on instance profiles (or any environment using the default credential chain) without a named profile configured in `~/.aws/credentials`.

**Changes:**
1. `AWSClients`: only call `boto3.setup_default_session` when a profile is explicitly provided; otherwise let boto3's default credential chain resolve credentials (env vars, instance profile, container credentials).
2. `verify_env.py`: change `--profile` default from `'default'` to `None`.
3. `readme.md`: update help text to document the optional behavior.
4. `tests`: add `test_aws_clients.py` with 4 unit tests covering both paths (profile provided and omitted).

**Backward compatibility:** users currently passing `--profile default` or `--profile myprofile` get identical behavior. The only change is that omitting `--profile` now uses boto3's credential chain instead of requiring a profile literally named "default".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.