### PR TITLE
docs(MWAA): Point users to SAW runbooks before verify_env

### DIFF
--- a/MWAA/readme.md
+++ b/MWAA/readme.md
@@ -1,5 +1,7 @@
 # MWAA(Amazon Managed Workflows for Apache Airflow)
 
+> **Having trouble?** Start with the automated troubleshooting runbooks. Use [AWSSupport-TroubleshootMWAAEnvironmentCreation](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-troubleshoot-mwaa-environment-creation.html) to diagnose environment creation failures, or run [AWSSupport-ValidateMWAADependencies](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-awssupport-validatemwaadependencies.html) to validate your environment's dependencies and configuration. These runbooks are maintained with the latest diagnostics and are the recommended first step.
+
 ## verify environment
 An environment can fail to create for the following reasons [documented here](https://docs.aws.amazon.com/mwaa/latest/userguide/troubleshooting.html#t-create-environ-failed)
 


### PR DESCRIPTION

  ## What does this PR do?

  Adds a short callout to the top of the MWAA `readme.md` directing users to the automated Systems Manager Automation troubleshooting runbooks ([AWSSupport-TroubleshootMWAAEnvironmentCreation](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-troubleshoot-mwaa-environment-creation.html) and [AWSSupport-ValidateMWAADependencies](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-awssupport-validatemwaadependencies.html)) as the recommended first step for diagnosing environment creation and dependency failures. These runbooks are maintained with more current diagnostics than the open-source `verify_env.py` script.

  This is a documentation-only change; no script logic is modified.

  ## AWS service / folder

  MWAA

  ## Checklist

  - [x] Documentation-only change; no new tool or source code added
  - [x] Source code only, no compiled/pre-built binaries
  - [x] Verified the runbook links resolve to the correct AWS documentation pages
  - [x] No hardcoded credentials, account IDs, or other sensitive values

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

